### PR TITLE
WIP: updates for v12 cli release

### DIFF
--- a/docs/cookbook/diy-dat.md
+++ b/docs/cookbook/diy-dat.md
@@ -2,6 +2,8 @@
 
 In this guide, we will show how to develop applications with the Dat ecosystem. The Dat ecosystem is very modular making it easy to develop custom applications using Dat.
 
+This tutorial will follow the steps for sharing and downloading files using Dat. In practice, we implement these in [dat-node](https://github.com/datproject/dat-node), a high-level module for using Dat that provides easy access to the core Dat modules.
+
 For any Dat application, there are three essential modules you will start with: 
 
 1. [hyperdrive](https://npmjs.org/hyperdrive) for file synchronization and versioning

--- a/docs/ecosystem.md
+++ b/docs/ecosystem.md
@@ -1,14 +1,15 @@
 # Dat Module Ecosystem
 
-We have built and contributed to a variety of modules that support our work on Dat as well as the larger data and code ecosystem. Feel free to go deeper and see the implementations we are using in the [Dat command-line tool](https://github.com/datproject/dat) and the [Dat-js](https://github.com/joehand/dat-js), the javascript Dat module.
+We have built and contributed to a variety of modules that support our work on Dat as well as the larger data and code ecosystem. Feel free to go deeper and see the implementations we are using in the [Dat command-line tool](https://github.com/datproject/dat) and the [Dat Desktop](https://github.com/datproject/dat-desktop).
 
 Dat embraces the Unix philosophy: a modular design with composable parts. All of the pieces can be replaced with alternative implementations as long as they implement the abstract API.
 
 ## Public Interface Modules
 
-* [dat](dat) - the command line interface for sharing and downloading files
-* [dat.land](dat.land) - repository for the [dat.land](https://dat.land) website, a public data registry and sharing
-* [dat desktop](https://github.com/juliangruber/dat-desktop) - dat desktop application for sharing and downloading files
+* [dat](https://github.com/datproject/dat) - the command line interface for sharing and downloading files
+* [Dat Desktop](https://github.com/datproject/dat-desktop) - dat desktop application for sharing and downloading files
+* [datproject.org](https://github.com/datproject/datproject.org/) - repository for the Dat project website, a public data registry and sharing
+* [Dat Protocol](https://www.datprotocol.com/) - The Dat protocol specification
 
 ## File and Block Component Modules
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -34,11 +34,11 @@ Yes, it is our only implementation. Find it on GitHub: [dat-node](http://github.
 
 ### Is there an online dataset registry, like GitHub?
 
-Yes. See [datproject/datfolder](http://github.com/datproject/datfolder) on GitHub.
+Yes. See [datproject/datproject.org](https://github.com/datproject/datproject.org) on GitHub.
 
 ### Is there a desktop application?
 
-Yes. See [datproject/dat-desktop](http://github.com/datproject/dat-desktop) on GitHub.
+Yes, you'll be able to [install soon](https://datproject.org/install)! See [datproject/dat-desktop](http://github.com/datproject/dat-desktop) on GitHub for development updates.
 
 ### Do you plan to have Python or R or other third-party language integrations?
 
@@ -82,7 +82,7 @@ Dat uses hyperdrive and a variety of other modules. Hyperdrive and Dat are compa
 
 ### Does Dat use WebRTC?
 
-Our [datfolder](http://github.com/datproject/datfolder) prototype used WebRTC to transfer data between peers. Moving forward, we are not planning on immediately supporting WebRTC in any Dat client because of reliability issues and lack of support in non-browser environments. Our future browser implementations of Dat will use websockets to transfer data to non-browser Dat interfaces.
+No. We implemented a prototype web version using WebRTC. Moving forward, we are not planning on immediately supporting WebRTC in any Dat client because of reliability issues and lack of support in non-browser environments. Our future browser implementations of Dat will use websockets to transfer data to non-browser Dat interfaces.
 
 ### Dat on the CLI isn't connecting, how do I debug?
 


### PR DESCRIPTION
* Fixing old references
* Updates for CLI changes
* Other outdates things

On merge this *should* also replace the datproject/dat readme.md file to be the landing page of docs.datproject.org for v12 release.