### PR TITLE
Fix typo in example code within browser.md

### DIFF
--- a/docs/cookbook/browser.md
+++ b/docs/cookbook/browser.md
@@ -101,7 +101,7 @@ var archive = hyperdrive()
 var link = archive.discoveryKey.toString('hex')
 
 var swarm = webrtc(signalhub(link, DEFAULT_SIGNALHUBS))
-swarm.on('peer', function (peer) {
+swarm.on('peer', function (conn) {
   var peer = archive.replicate({
     upload: true,
     download: true


### PR DESCRIPTION
There is confusion with `conn` being undefined and the `peer` argument being overridden in the function body. I think this is caused by the argument being incorrectly named `peer` rather than `conn`.