### PR TITLE
Change `deploy` branch to `master` in how-to-contribute readme’s.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Repository for the documentation of the Dat Project ecosystem. View the docs at 
 
 ## Writing & Editing Docs
 
-[See docs folder](docs/readme.md) for information on editing and adding docs. Once you finish editing the docs, send a PR to the `deploy` branch to get the edits automatically deployed.
+[See docs folder](docs/readme.md) for information on editing and adding docs. Once you finish editing the docs, send a PR to the `master` branch to get the edits automatically deployed.
 
 ### Creating + Generating Paper from Markdown
 

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -10,5 +10,5 @@ This documentation uses [minidocs](https://github.com/freeman-lab/minidocs).
 ## Deploying to Website
 
 1. Write documentation
-2. Open PR to the `deploy` branch
+2. Open PR to the `master` branch
 3. When PR is merged, Travis will automatically deploy the docs!


### PR DESCRIPTION
There is not a branch called `deploy` which could be confusing. As other PR’s are directed to master I am assuming that master is actually the deploy branch.