### PR TITLE
Add security as a top-level item

### DIFF
--- a/docs/contents.json
+++ b/docs/contents.json
@@ -5,6 +5,7 @@
     "Getting Started": "tutorial.md",
     "Key Concepts": "concepts.md",
     "Terminology": "terms.md",
+    "Security & Privacy": "security.md",
     "Frequently Asked Questions": "faq.md",
     "Troubleshooting": "troubleshooting.md"
   },

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -121,51 +121,6 @@ Dat uses one keypair to verify that only one writer is allowed to add or update 
 
 We are interested in implementations of multi-party writers to dat. Come talk to us in #dat on freenode for more information.
 
-## Security & Privacy
-
-### Can other users tell what I am downloading? 
-
-Users only connect to other users with the same dat link. Anyone with a dat link can see other users that are sharing that link and their IP addresses.
-
-We are thinking more about how to ensure reader privacy. See [this blog post](https://blog.datproject.org/2016/12/12/reader-privacy-on-the-p2p-web/) for more discussion.
-
-### Is data shared over Dat encrypted?
-
-Yes, data shared over Dat is encrypted in transit using the public key (Dat link). When you share a Dat, you must share the public key with another user so they can download it. We use that key on both ends to encrypt the data so both users can read the data but we can ensure the data is not transferred over the internet without encryption.
-
-### Is it possible to discover public keys via man-in-the-middle?
-
-One of the key elements of Dat privacy is that the public key is never used in any discovery network. The public key is hashed, creating the discovery key. Whenever peers attempt to connect to each other, they use the discovery key.
-
-Data is encrypted using the public key, so it is important that this key stays secure.
-
-### Can anyone download my data? What if I don't share the key with anyone?
-
-Only someone with the key can download data for Dat. It is the responsibility of the user that the Dat link is only shared with people who should access the data. The key is never sent over the network via Dat. We do not track keys centrally. It is almost impossible for [keys to overlap](http://docs.datproject.org/faq#are-the-dat-links-guaranteed-to-be-unique-) (and thus to guess keys).
-
-### How can I create stronger privacy protections for my data?
-
-As long as the public key isn't shared outside of your team, the content will be secure (though the IP addresses and discovery key may become known). You can take a few steps further to improve privacy (generally at the cost of ease of use):
-
-1. Disable bittorrent DHT discovery (using only DNS discovery), use `--no-dht` flag in CLI.
-2. Whitelist IP addresses
-3. Run your own discovery servers
-4. Encrypt contents before adding to dat (content is automatically encrypted in transit but this would also require decrypting after arrival).
-
-Only some of these options can be done in the current command line tool. Feel free to PR options to make these easier to configure!
-
-### How does Dat make sure I download the correct content?
-
-Dat uses the concept of a [Merkle tree](https://en.wikipedia.org/wiki/Merkle_tree) to make sure content is not tampered with. When content is added to a Dat we  cryptographically fingerprint it and add it to the tree. On download, we can use the tree to make sure the content has not changed and the parent hashes match.
-
-### How does Dat help to improve transparency?
-
-Dat uses an append-only to track changes over time. An append-only log shows all of the changes for a given Dat since it was shared. We use this for version control but it can also bolster transparency for a dataset. Any changes to a dataset will be tracked and you can see what changed and when.
-
-### Privacy and Security Versus Bittorrent
-
-As a peer to peer network, Dat faces similar privacy risks as Bittorrent. When you download a dataset, your IP address is exposed to the users sharing that dataset. This may lead to honeypot servers collecting IP addresses, as we've seen in Bittorrent. However, with dataset sharing we can create a web of trust model where specific institutions are trusted as primary sources for datasets, diminishing the sharing of IP addresses. [Read more](https://datproject.org/blog/2016-12-18-p2p-reader-privacy) about reader privacy in the p2p web.
-
 ## Dat vs ?
 
 Dat has a lot of overlap with other distributed web tools, data management tools, and distributed version control. Below are some of the most common questions. See more in depth technical comparisons in the [Dat whitepaper](https://github.com/datproject/docs/blob/master/papers/dat-paper.md#5-existing-work).

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -26,7 +26,11 @@ backups to be stored efficiently on an external hard drive or a cloud serve by u
 
 #### Security
 
-Dat transfers files over an encrypted connection using state-of-the-art cryptography. Only users with your unique link can access your files. Your dat link allows users to download and re-share your files. To write updates to a dat, users must have the secret key. Dat also verifies the hashes of files on download so no malicious content can be added.
+Dat transfers files over an encrypted connection using state-of-the-art
+cryptography. Only users with your unique link can access your files. Your dat
+link allows users to download and re-share your files. To write updates to
+a dat, users must have the secret key. Dat also verifies the hashes of files on
+download so no malicious content can be added. [Read more about security in dat.](/security)
 
 ## Who we are
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,45 @@
+## Security & Privacy
+
+### Can other users tell what I am downloading? 
+
+Users only connect to other users with the same dat link. Anyone with a dat link can see other users that are sharing that link and their IP addresses.
+
+We are thinking more about how to ensure reader privacy. See [this blog post](https://blog.datproject.org/2016/12/12/reader-privacy-on-the-p2p-web/) for more discussion.
+
+### Is data shared over Dat encrypted?
+
+Yes, data shared over Dat is encrypted in transit using the public key (Dat link). When you share a Dat, you must share the public key with another user so they can download it. We use that key on both ends to encrypt the data so both users can read the data but we can ensure the data is not transferred over the internet without encryption.
+
+### Is it possible to discover public keys via man-in-the-middle?
+
+One of the key elements of Dat privacy is that the public key is never used in any discovery network. The public key is hashed, creating the discovery key. Whenever peers attempt to connect to each other, they use the discovery key.
+
+Data is encrypted using the public key, so it is important that this key stays secure.
+
+### Can anyone download my data? What if I don't share the key with anyone?
+
+Only someone with the key can download data for Dat. It is the responsibility of the user that the Dat link is only shared with people who should access the data. The key is never sent over the network via Dat. We do not track keys centrally. It is almost impossible for [keys to overlap](http://docs.datproject.org/faq#are-the-dat-links-guaranteed-to-be-unique-) (and thus to guess keys).
+
+### How can I create stronger privacy protections for my data?
+
+As long as the public key isn't shared outside of your team, the content will be secure (though the IP addresses and discovery key may become known). You can take a few steps further to improve privacy (generally at the cost of ease of use):
+
+1. Disable bittorrent DHT discovery (using only DNS discovery), use `--no-dht` flag in CLI.
+2. Whitelist IP addresses
+3. Run your own discovery servers
+4. Encrypt contents before adding to dat (content is automatically encrypted in transit but this would also require decrypting after arrival).
+
+Only some of these options can be done in the current command line tool. Feel free to PR options to make these easier to configure!
+
+### How does Dat make sure I download the correct content?
+
+Dat uses the concept of a [Merkle tree](https://en.wikipedia.org/wiki/Merkle_tree) to make sure content is not tampered with. When content is added to a Dat we  cryptographically fingerprint it and add it to the tree. On download, we can use the tree to make sure the content has not changed and the parent hashes match.
+
+### How does Dat help to improve transparency?
+
+Dat uses an append-only to track changes over time. An append-only log shows all of the changes for a given Dat since it was shared. We use this for version control but it can also bolster transparency for a dataset. Any changes to a dataset will be tracked and you can see what changed and when.
+
+### Privacy and Security Versus Bittorrent
+
+As a peer to peer network, Dat faces similar privacy risks as Bittorrent. When you download a dataset, your IP address is exposed to the users sharing that dataset. This may lead to honeypot servers collecting IP addresses, as we've seen in Bittorrent. However, with dataset sharing we can create a web of trust model where specific institutions are trusted as primary sources for datasets, diminishing the sharing of IP addresses. [Read more](https://datproject.org/blog/2016-12-18-p2p-reader-privacy) about reader privacy in the p2p web.
+


### PR DESCRIPTION
A lot of people have trouble finding 'security and privacy'  hidden behind the faq, so i added it as a top level item