### PR TITLE
Add a meta-reference to 'docs' github repo

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -38,4 +38,8 @@ Note: There has not been an independent security audit for Dat. Use at your own 
 
 Dat is funded by [Code for Science & Society](https://codeforscience.org), a nonprofit supporting open source tools that benefit science and society. Dat also has a vibrant global community of developers building apps on the Dat protocol.
 
+These documents are collaboratively maintained on Github under
+[datproject/docs](https://github.com/datproject/docs). We welcome correctsion
+and requests for clarification.
+
 Enough reading, more doing? [Head over to Installation to get started.](/install)

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -39,7 +39,7 @@ Note: There has not been an independent security audit for Dat. Use at your own 
 Dat is funded by [Code for Science & Society](https://codeforscience.org), a nonprofit supporting open source tools that benefit science and society. Dat also has a vibrant global community of developers building apps on the Dat protocol.
 
 These documents are collaboratively maintained on Github under
-[datproject/docs](https://github.com/datproject/docs). We welcome correctsion
+[datproject/docs](https://github.com/datproject/docs). We welcome corrections
 and requests for clarification.
 
 Enough reading, more doing? [Head over to Installation to get started.](/install)


### PR DESCRIPTION
To address concern raised in #125.

I'm not sure this really solves the problem; it's sort of buried at the bottom of the front page. On the other hand, any of:
- "edit on github" corner ribbon/logo
- a top-bar link along with "INSTALL" and "HOME" (which I don't think would show on mobile)
- a link on the sidebar
- a footer

feel like overkill. I like how simple the docs are currently. Maybe also a FAQ entry?