### PR TITLE
One sentence per line to make diffs easier

### DIFF
--- a/docs/getting-started-faq.md
+++ b/docs/getting-started-faq.md
@@ -8,17 +8,35 @@ sidebar_label: Dat FAQ
 
 #### What happens if existing contributors to Dat discontinue support? Will my data be inaccessible?
 
-Dat software is built with long-term sustainability as a focus. For us, this goes beyond financial sustainability. Establishing lasting data archives depends on a transparent and open process, a wider open source community, and ensuring no single entity or technology is responsible for data storage or access.
+Dat software is built with long-term sustainability as a focus.
+For us, this goes beyond financial sustainability.
+Establishing lasting data archives depends on a transparent and open process, a wider open source community, and ensuring no single entity or technology is responsible for data storage or access.
 
-**Public Design Process.** All discussion related to the design and development of Dat project software is public (either on IRC or GitHub). Dat software is released with open source licenses and will always be freely available.
+**Public Design Process.**
+All discussion related to the design and development of Dat project software is public (either on IRC or GitHub).
+Dat software is released with open source licenses and will always be freely available.
 
-**Open Source Community.** The Dat team develops with [pragmatic modularity](https://mafinto.sh/blog/pragmatic-modularity.html) in mind. Dat's high-level, user facing software is composed of small, highly focused underlying modules, many of which are used outside of the Dat project. This creates a broader community to ensure Dat software will continue to be used and supported, regardless of the future actions of individual community members working closely with Dat today.
+**Open Source Community.**
+The Dat team develops with [pragmatic modularity](https://mafinto.sh/blog/pragmatic-modularity.html) in mind.
+Dat's high-level, user facing software is composed of small, highly focused underlying modules, many of which are used outside of the Dat project.
+This creates a broader community to ensure Dat software will continue to be used and supported, regardless of the future actions of individual community members working closely with Dat today.
 
-**No Lock In.** We want you to use Dat because you love it, not because it's difficult to get your data out. Dat does not import or copy your data into specialized databases. You can easily move your data around, and Dat keeps it intact in its original form. You can even simultaneously host your data on HTTP along with Dat to ensure backwards compatibility with existing web tools. You'll never be locked into using Dat software.
+**No Lock In.**
+We want you to use Dat because you love it, not because it's difficult to get your data out.
+Dat does not import or copy your data into specialized databases.
+You can easily move your data around, and Dat keeps it intact in its original form.
+You can even simultaneously host your data on HTTP along with Dat to ensure backwards compatibility with existing web tools.
+You'll never be locked into using Dat software.
 
-**Distributed Storage.** Dat is built to distribute storage and bandwidth costs throughout the network. Data hosting and bandwidth are some of the main costs for long-term data storage. By using Dat we can help ensure there are no single points of failure for data storage. Dat does not host any data.
+**Distributed Storage.**
+Dat is built to distribute storage and bandwidth costs throughout the network.
+Data hosting and bandwidth are some of the main costs for long-term data storage.
+By using Dat we can help ensure there are no single points of failure for data storage.
+Dat does not host any data.
 
-**No Centralized Servers.** Dat transfers all data directly between peers and has little reliance on Dat maintaining servers. We have public servers for peers to help discover each other, but those use very little bandwidth and anyone can run them.
+**No Centralized Servers.**
+Dat transfers all data directly between peers and has little reliance on Dat maintaining servers.
+We have public servers for peers to help discover each other, but those use very little bandwidth and anyone can run them.
 
 ## Dat Usage
 
@@ -29,31 +47,41 @@ We have some networking debugging tools available in the CLI:
 1. Try running `dat doctor` and following the instructions
 2. Try running your command with `DEBUG=discovery* ` in front, e.g. `DEBUG=discovery* dat sync`
 
-When reading debug output, look for `inbound connection` (which means someone else successfully connected to you) or `onconnect` (which means you successfully connected to someone else). `discovery peer=` messages mean you found a candidate and will try to connect to them.
+When reading debug output, look for `inbound connection` (which means someone else successfully connected to you) or `onconnect` (which means you successfully connected to someone else).
+`discovery peer=` messages mean you found a candidate and will try to connect to them.
 
 ### How do Dat peers discover one another on the Internet?
 
-Dat is very flexible. It currently uses three methods for peer discovery, and you can implement and add your own.
+Dat is very flexible.
+It currently uses three methods for peer discovery, and you can implement and add your own.
 
  1) Multicast UDP, which finds peers on your local network,
  2) A distributed hash table, which operates without needing a central server, and
  3) A collection of signaling servers that run a modified version of DNS.
 
-We run a signaling server for users of our client applications. Anyone can run a signaling server, and you can configure your applications to use the servers you wish.
+We run a signaling server for users of our client applications.
+Anyone can run a signaling server, and you can configure your applications to use the servers you wish.
 
 ### Are the Dat read keys guaranteed to be unique?
 
-It's not technically impossible that they'd collide, but it's extremely unlikely. Dat read keys are 32 bytes long. That's 1.1579 x 10^77 possible numbers!
+It's not technically impossible that they'd collide, but it's extremely unlikely.
+Dat read keys are 32 bytes long.
+That's 1.1579 x 10^77 possible numbers!
 
 ### What are the limits on file sizes?
 
-The Dat software does not have any inherent size limits. The Dat project does not store any data itself. All data is transferred directly between peers. Depending on where the data is hosted, there may be storage or bandwidth limits.
+The Dat software does not have any inherent size limits.
+The Dat project does not store any data itself.
+All data is transferred directly between peers.
+Depending on where the data is hosted, there may be storage or bandwidth limits.
 
 ### Does Dat store version history?
 
-Version history is built into our core modules but only some clients support it (more soon!). We have dat tools, intended for servers, such as [hypercore-archiver](https://github.com/mafintosh/hypercore-archiver) and [hypercloud](https://github.com/datprotocol/hypercloud) that store the full content history.
+Version history is built into our core modules but only some clients support it (more soon!).
+We have dat tools, intended for servers, such as [hypercore-archiver](https://github.com/mafintosh/hypercore-archiver) and [hypercloud](https://github.com/datprotocol/hypercloud) that store the full content history.
 
-Once historic content is saved, you can access it in the dat command line. First, you can log the history of the archive to see what version you want:
+Once historic content is saved, you can access it in the dat command line.
+First, you can log the history of the archive to see what version you want:
 
 ```sh
 ❯ dat log /my-dat
@@ -91,9 +119,12 @@ Then you can download specific files or versions using the `--http` interface:
 dat sync /my-dat --http
 ```
 
-Once running, visit `localhost:8080` to view the latest content. Set the version flag, `localhost:8080/?version=3` to see a specific version. Clicking on a file will download that version of the file (assuming its available locally or on the network).
+Once running, visit `localhost:8080` to view the latest content.
+Set the version flag, `localhost:8080/?version=3` to see a specific version.
+Clicking on a file will download that version of the file (assuming its available locally or on the network).
 
-We are working on adding a local version history backup in the command line and desktop applications. We'll also further develop the interfaces for using and checking out older versions of files.
+We are working on adding a local version history backup in the command line and desktop applications.
+We'll also further develop the interfaces for using and checking out older versions of files.
 
 ### Is there a JavaScript or Node.js implementation?
 
@@ -101,27 +132,45 @@ Yes! On GitHub, use the Dat [SDK](https://github.com/datproject/sdk).
 
 ### Can multiple people write to one archive?
 
-Currently, Dat uses one keypair to verify that only one writer is allowed to add or update files in a Dat. This means that all peers connecting to the data are read-only right now. If the original creator of the dat loses the keypair, the data can no longer be updated.
+Currently, Dat uses one keypair to verify that only one writer is allowed to add or update files in a Dat.
+This means that all peers connecting to the data are read-only right now.
+If the original creator of the dat loses the keypair, the data can no longer be updated.
 
-[HyperDB](https://github.com/mafintosh/hyperdb/) adds multiwriter support for Dat. It is under [active development](https://github.com/datproject/planning).
+[HyperDB](https://github.com/mafintosh/hyperdb/) adds multiwriter support for Dat.
+It is under [active development](https://github.com/datproject/planning).
  
 ## Dat vs ?
 
-There are a lot of distributed web tools, data management tools, and distributed version control tools in development today. Below are answers to some common questions about Dat is the same or different from them.
+There are a lot of distributed web tools, data management tools, and distributed version control tools in development today.
+Below are answers to some common questions about Dat is the same or different from them.
 
 ### How is Dat different than IPFS?
 
-IPFS and Dat share a number of underlying similarities but address different problems. Both deduplicate content-addressed pieces of data and have a mechanism for searching for peers who have a specific piece of data. Both have implementations which work in modern Web browsers, as well as command line tools.
+IPFS and Dat share a number of underlying similarities but address different problems.
+Both deduplicate content-addressed pieces of data and have a mechanism for searching for peers who have a specific piece of data.
+Both have implementations which work in modern Web browsers, as well as command line tools.
 
-The two systems also have a number of differences. Dat keeps a secure version log of changes to a dataset over time which allows Dat to act as a version control tool. The type of Merkle tree used by Dat lets peers compare which pieces of a specific version of a dataset they each have and efficiently exchange the deltas to complete a full sync. It is not possible to synchronize or version a dataset in this way in IPFS without implementing such functionality yourself, as IPFS provides a CDN and/or filesystem interface but not a synchronization mechanism.
+The two systems also have a number of differences.
+Dat keeps a secure version log of changes to a dataset over time which allows Dat to act as a version control tool.
+The type of Merkle tree used by Dat lets peers compare which pieces of a specific version of a dataset they each have and efficiently exchange the deltas to complete a full sync.
+It is not possible to synchronize or version a dataset in this way in IPFS without implementing such functionality yourself, as IPFS provides a CDN and/or filesystem interface but not a synchronization mechanism.
 
-Dat prioritizes speed and efficiency for the most basic use cases, especially when sharing large datasets. Dat does not duplicate data on the local filesystem, unlike IPFS which duplicates on import (although IPFS now has [experimental support for no-copy imports](https://github.com/ipfs/go-ipfs/issues/875)). Dat's pieces can also be easily decoupled for implementing lower-level object stores. See [hypercore](http://github.com/mafintosh/hypercore) and [hyperdb](http://github.com/mafintosh/hyperdb) for more information.
+Dat prioritizes speed and efficiency for the most basic use cases, especially when sharing large datasets.
+Dat does not duplicate data on the local filesystem, unlike IPFS which duplicates on import (although IPFS now has [experimental support for no-copy imports](https://github.com/ipfs/go-ipfs/issues/875)).
+Dat's pieces can also be easily decoupled for implementing lower-level object stores.
+See [hypercore](http://github.com/mafintosh/hypercore) and [hyperdb](http://github.com/mafintosh/hyperdb) for more information.
 
-In order for IPFS to provide guarantees about interoperability, IPFS applications must use only the IPFS network stack. In contrast, Dat is only an application protocol and is agnostic to which network protocols (transports and naming systems) are used.
+In order for IPFS to provide guarantees about interoperability, IPFS applications must use only the IPFS network stack.
+In contrast, Dat is only an application protocol and is agnostic to which network protocols (transports and naming systems) are used.
 
 ### How is dat different than Academic Torrents or BitTorrent?
 
-Academic Torrents uses BitTorrent to share scientific datasets. BitTorrent is a much older technology that was not designed for this use case, and presents many drawbacks. BitTorrent takes a single indelible snapshot of a collection of files, forcing users to start over when they need to add or change data. Dat's ability to update data and efficiently synchronize changes is much better suited to active research on datasets that grow and change. BitTorrent is also inefficient at providing random access to data in larger datasets. We see BitTorrent as an intermediate solution that we've used as inspiration and guidance when designing Dat, and have significantly improved upon.
+Academic Torrents uses BitTorrent to share scientific datasets.
+BitTorrent is a much older technology that was not designed for this use case, and presents many drawbacks.
+BitTorrent takes a single indelible snapshot of a collection of files, forcing users to start over when they need to add or change data.
+Dat's ability to update data and efficiently synchronize changes is much better suited to active research on datasets that grow and change.
+BitTorrent is also inefficient at providing random access to data in larger datasets.
+We see BitTorrent as an intermediate solution that we've used as inspiration and guidance when designing Dat, and have significantly improved upon.
 
 ## Under the Hood
 
@@ -129,11 +178,15 @@ Academic Torrents uses BitTorrent to share scientific datasets. BitTorrent is a 
 
 [Hyperdrive](http://github.com/mafintosh/hyperdrive) is a file sharing network built to power Dat.
 
-Dat is built on hyperdrive and other modules. Hyperdrive and Dat are compatible with each other but hyperdrive works at a lower level. Dat presents a user-friendly interface for scientists, researchers, and data analysts.
+Dat is built on hyperdrive and other modules.
+Hyperdrive and Dat are compatible with each other but hyperdrive works at a lower level.
+Dat presents a user-friendly interface for scientists, researchers, and data analysts.
 
 ### What if I don't want to download all the data? Does dat have an index?
 
-Yes, you can tell Dat to only download the data you want using our Node.js API. Use `sparse` mode in `hyperdrive` or `dat-node`, which configure them to only download content that you later ask for. To do this, simply pass `{sparse: true}` when you create the dat or hyperdrive:
+Yes, you can tell Dat to only download the data you want using our Node.js API.
+Use `sparse` mode in `hyperdrive` or `dat-node`, which configure them to only download content that you later ask for.
+To do this, simply pass `{sparse: true}` when you create the dat or hyperdrive:
 
 ```js
 var Dat = require('dat-node')

--- a/docs/getting-started-installation.md
+++ b/docs/getting-started-installation.md
@@ -4,14 +4,14 @@ title: Installing Dat
 sidebar_label: Installation
 ---
 
-This page will show you how to install Dat for the command line, and use it in JavaScript applications. There are [many other applications](https://dat.land/apps) built on Dat, such as [Beaker Browser](https://beakerbrowser.com), which provide a graphical user interface.
+This page will show you how to install Dat for the command line, and use it in JavaScript applications.
+There are [many other applications](https://dat.land/apps) built on Dat, such as [Beaker Browser](https://beakerbrowser.com), which provide a graphical user interface.
 
 Dat can be used as a command line tool, a Node.js module, and a JavaScript library:
 
 * See below to install the `dat` command line tool.
 * Node.js - `npm install dat` and [read more](https://github.com/datproject/dat-node).
 * JavaScript - `npm install dat-js` and [read more](https://github.com/datproject/dat-js).
-
 
 ## Installing Dat on the Command Line
 
@@ -21,12 +21,12 @@ To install Dat, you can use `wget` or `curl` to download and get started:
 wget -qO- https://raw.githubusercontent.com/datproject/dat/master/download.sh | bash
 ```
 
-
 ```
 curl -o- https://raw.githubusercontent.com/datproject/dat/master/download.sh | bash
 ```
 
-Once the install finishes, you should be able to run the `$ dat` command in your terminal. If not, see the [installation troubleshooting](usingdat-troubleshooting.md#installation-troubleshooting) for tips.
+Once the install finishes, you should be able to run the `$ dat` command in your terminal.
+If not, see the [installation troubleshooting](usingdat-troubleshooting.md#installation-troubleshooting) for tips.
 
 ### Using npm
 
@@ -36,9 +36,11 @@ If you have `npm`, you can install Dat with it:
 npm install -g dat
 ```
 
-Make sure you have `node` and `npm` installed first. If not, see the prerequisites section below. We recommend `npm` because it makes it easy to install new versions of `dat` when they are released.
+Make sure you have `node` and `npm` installed first.
+If not, see the prerequisites section below. We recommend `npm` because it makes it easy to install new versions of `dat` when they are released.
 
-Once `npm install` finishes, you should be able to run the `$ dat` command. If not, see the [installation troubleshooting](usingdat-troubleshooting.md#installation-troubleshooting) for tips.
+Once `npm install` finishes, you should be able to run the `$ dat` command.
+If not, see the [installation troubleshooting](usingdat-troubleshooting.md#installation-troubleshooting) for tips.
 
 #### NPM Prerequisites
 

--- a/docs/getting-started-intro.md
+++ b/docs/getting-started-intro.md
@@ -4,49 +4,76 @@ title: What is Dat?
 sidebar_label: Intro to Dat
 ---
 
-Dat is a protocol for sharing data between computers. By making sure changes in data are transparent, everyone receives only the data they want, and by connecting computers directly (rather than using a cloud server), Dat powers communities building the next-generation Web.
+Dat is a protocol for sharing data between computers.
+By making sure changes in data are transparent, everyone receives only the data they want, and by connecting computers directly (rather than using a cloud server), Dat powers communities building the next-generation Web.
 
 ## Welcome to Dat
 
-Ever tried moving large files and folders to other computers? Usually this involves one of a few strategies: being in the same location (USB stick), using a cloud service (Dropbox), or using old but reliable technical tools (rsync). None of these easily store, track, and share your data over time. People often are stuck choosing between security, speed, or ease of use. Dat provides all three by using a state-of-the-art technical foundation and user friendly tools for fast and encrypted file sharing that you control.
+Ever tried moving large files and folders to other computers?
+Usually this involves one of a few strategies: being in the same location (USB stick), using a cloud service (Dropbox), or using old but reliable technical tools (rsync).
+None of these easily store, track, and share your data over time.
+People often are stuck choosing between security, speed, or ease of use.
+Dat provides all three by using a state-of-the-art technical foundation and user friendly tools for fast and encrypted file sharing that you control.
 
-Dat is free software built for the public by an open source consortium of contributors. Researchers, analysts, libraries, and universities are [already using Dat](https://www.nytimes.com/2017/03/06/science/donald-trump-data-rescue-science.html) to archive and distribute scientific data. Developers are building applications on Dat for [browsing peer-to-peer websites](https://beakerbrowser.com) and [offline editable maps](https://www.digital-democracy.org/blog/update-from-the-ecuadorian-amazon/).  Anyone can use Dat to backup files or share cute cat pictures with a friend. Install and get started today by using the desktop application, command line, or JavaScript library.
+Dat is free software built for the public by an open source consortium of contributors.
+Researchers, analysts, libraries, and universities are [already using Dat](https://www.nytimes.com/2017/03/06/science/donald-trump-data-rescue-science.html) to archive and distribute scientific data.
+Developers are building applications on Dat for [browsing peer-to-peer websites](https://beakerbrowser.com) and [offline editable maps](https://www.digital-democracy.org/blog/update-from-the-ecuadorian-amazon/).
+Anyone can use Dat to backup files or share cute cat pictures with a friend.
+Install and get started today by using the desktop application, command line, or JavaScript library.
 
-Ready to try it? [Head over to Installation to get started.](getting-started-installation.md)
+Ready to try it?
+[Head over to Installation to get started.](getting-started-installation.md)
 
 ## Why Dat?
 
-Cloud services, such as Dropbox or GitHub, force users to store data on places outside of their control. Until now, it has been very difficult to avoid centralized servers without major sacrifices. Dat's unique distributed network allows users to store data where they want. By decentralizing storage, Dat also increases speeds by downloading from many sources at the same time.
+Cloud services, such as Dropbox or GitHub, force users to store data on places outside of their control.
+Until now, it has been very difficult to avoid centralized servers without major sacrifices.
+Dat's unique distributed network allows users to store data where they want.
+By decentralizing storage, Dat also increases speeds by downloading from many sources at the same time.
 
-Having a history of how files have changed is essential for effective collaboration and reproducibility. Git has been promoted as a solution for history, but becomes slow with large files, and has a high learning curve. Git is designed for editing source code, while Dat is designed for sharing files. With a few simple commands, you can version files of any size. People can quickly get the latest files or download previous versions.
+Having a history of how files have changed is essential for effective collaboration and reproducibility.
+Git has been promoted as a solution for history, but becomes slow with large files, and has a high learning curve.
+Git is designed for editing source code, while Dat is designed for sharing files.
+With a few simple commands, you can version files of any size.
+People can quickly get the latest files or download previous versions.
 
-In sum, we've taken the best parts of Git, BitTorrent, and Dropbox to design Dat. Learn more about how it all works by reading [How Dat Works](https://datprotocol.github.io/how-dat-works) or get more in depth at [datprotocol.com](https://datprotocol.com).
+In sum, we've taken the best parts of Git, BitTorrent, and Dropbox to design Dat.
+Learn more about how it all works by reading [How Dat Works](https://datprotocol.github.io/how-dat-works) or get more in depth at [datprotocol.com](https://datprotocol.com).
 
 #### Distributed Network
 
-Unlike cloud services like Dropbox or Google Drive, Dat works on a distributed network. This means Dat transfers files peer-to-peer, without needing centralized servers. Dat's network makes file transfers faster, encrypted, and auditable. You can even use Dat on local networks for offline file sharing or local backups. Dat reduces bandwidth costs on popular files, as downloads are *distributed* across all available computers, rather than centralized from a single host.
+Unlike cloud services like Dropbox or Google Drive, Dat works on a distributed network.
+This means Dat transfers files peer-to-peer, without needing centralized servers.
+Dat's network makes file transfers faster, encrypted, and auditable.
+You can even use Dat on local networks for offline file sharing or local backups.
+Dat reduces bandwidth costs on popular files, as downloads are *distributed* across all available computers, rather than centralized from a single host.
 
 #### Data History
 
-Dat makes it easy for you to save old versions of files. With every file
-update, Dat automatically tracks your changes. You can even direct these
-backups to be stored efficiently on an external hard drive or a cloud server by using [our archiver](usingdat-server.md).
+Dat makes it easy for you to save old versions of files.
+With every file update, Dat automatically tracks your changes.
+You can even direct these backups to be stored efficiently on an external hard drive or a cloud server by using [our archiver](usingdat-server.md).
 
 #### Security
 
-Dat transfers files over an encrypted connection using state-of-the-art
-cryptography. Only users with your unique *read* key can access your files, allowing them to download, view, and re-share your files. To update the contents of a Dat, users must have the *write* key. By verifying hashes during transfer, Dat makes sure no data is altered or corrupted. As long as the read key isn't shared outside of your team, the content will remain private, while the *discovery* key and IP addresses of peers sharing the Dat can become known. Read more about [security in Dat.](learn-more-security.md)
+Dat transfers files over an encrypted connection using state-of-the-art cryptography.
+Only users with your unique *read* key can access your files, allowing them to download, view, and re-share your files.
+To update the contents of a Dat, users must have the *write* key.
+By verifying hashes during transfer, Dat makes sure no data is altered or corrupted.
+As long as the read key isn't shared outside of your team, the content will remain private, while the *discovery* key and IP addresses of peers sharing the Dat can become known.
+Read more about [security in Dat.](learn-more-security.md)
 
 Also please note: There has not been an independent security audit for Dat.
 
 ## Who we are
 
-Dat is a vibrant global community of people contributing and building software with the Dat protocol. The community hosts [weekly meetings](https://comm-comm.datproject.org/) to chat about Dat.
+Dat is a vibrant global community of people contributing and building software with the Dat protocol.
+The community hosts [weekly meetings](https://comm-comm.datproject.org/) to chat about Dat.
 
 The Dat Project is a fiscally supported project of [Code for Science & Society](https://codeforscience.org), a nonprofit supporting open source tools that benefit science and society. 
 
-These documents are collaboratively maintained on Github under
-[datproject/docs](https://github.com/datproject/docs). We welcome corrections
-and requests for clarification.
+These documents are collaboratively maintained on Github under [datproject/docs](https://github.com/datproject/docs).
+We welcome corrections and requests for clarification.
 
-Enough reading, more doing? Head over to [Installation](getting-started-installation.md) to get started.
+Enough reading, more doing?
+Head over to [Installation](getting-started-installation.md) to get started.

--- a/docs/learn-more-concepts.md
+++ b/docs/learn-more-concepts.md
@@ -5,53 +5,88 @@ title: Key Dat Concepts
 
 ## In Place Archiving
 
-You can turn any folder on your computer into *a dat*. We call this *in place archiving*. A dat is a regular folder with some magic attached. The magic is a set of metadata files, in a `.dat` folder. Dat uses the metadata to track file history and securely share your files. Your files and the `.dat` folder can be instantly synced to anywhere.
+You can turn any folder on your computer into *a dat*.
+We call this *in place archiving*.
+A dat is a regular folder with some magic attached.
+The magic is a set of metadata files, in a `.dat` folder.
+Dat uses the metadata to track file history and securely share your files.
+Your files and the `.dat` folder can be instantly synced to anywhere.
 
-Once you have installed Dat, you can use a single command to live sync your files to friends, backup to an external drive, and publish to a website (so people can download over http too!). The cool part is this all happens at the same time. If you go offline for a bit, no worries. Dat shares the latest files and any saved history once you are back online. These data transfers happen between the computers, forgoing any centralized source.
+Once you have installed Dat, you can use a single command to live sync your files to friends, backup to an external drive, and publish to a website (so people can download over http too!).
+The cool part is this all happens at the same time.
+If you go offline for a bit, no worries.
+Dat shares the latest files and any saved history once you are back online.
+These data transfers happen between the computers, forgoing any centralized source.
 
-In place archiving in Dat really means **any place**. Dat seamlessly syncs your files where you want and when you want. Dat's decentralized technology and automatic versioning will improve data availability and data quality without sacrificing ease of use.
+In place archiving in Dat really means **any place**.
+Dat seamlessly syncs your files where you want and when you want.
+Dat's decentralized technology and automatic versioning will improve data availability and data quality without sacrificing ease of use.
 
 ## Distributed Network
 
-Dat goes beyond regular archiving through its *distributed network*. When you share data, Dat sends data to many download locations at once, and they can sync the same data with each other! By connecting users directly Dat transfers files faster, especially sharing on a local network. Distributed syncing allows robust global archiving for public data.
+Dat goes beyond regular archiving through its *distributed network*.
+When you share data, Dat sends data to many download locations at once, and they can sync the same data with each other!
+By connecting users directly Dat transfers files faster, especially sharing on a local network.
+Distributed syncing allows robust global archiving for public data.
 
-The Dat read key controls access to your data. Any data shared in the network is encrypted using your read key. Learn more about Dat's security and privacy below or in [the faqs](getting-started-faq.md). We are also investigating ways to improve [reader privacy](https://blog.datproject.org/2016/12/12/reader-privacy-on-the-p2p-web/) for public data.
+The Dat read key controls access to your data.
+Any data shared in the network is encrypted using your read key.
+Learn more about Dat's security and privacy below or in [the faqs](getting-started-faq.md).
+We are also investigating ways to improve [reader privacy](https://blog.datproject.org/2016/12/12/reader-privacy-on-the-p2p-web/) for public data.
 
 ## Version History
 
-Dat automatically maintains a built-in version history whenever files are added. Dat uses this history to allow partial downloads of files, for example only getting the latest files. There are two types of versioning performed automatically by Dat. Metadata is stored in a folder called `.dat` in the main folder of a repository, and data is stored as normal files in the main folder.
+Dat automatically maintains a built-in version history whenever files are added.
+Dat uses this history to allow partial downloads of files, for example only getting the latest files.
+There are two types of versioning performed automatically by Dat.
+Metadata is stored in a folder called `.dat` in the main folder of a repository, and data is stored as normal files in the main folder.
 
-Dat uses append-only registers to store version history. This means all changes are written to the end of the file, growing over time.
+Dat uses append-only registers to store version history.
+This means all changes are written to the end of the file, growing over time.
 
 ### Metadata Versioning
 
-Dat acts as a one-to-one mirror of the state of a folder and all its contents. When importing files, Dat grabs the filesystem metadata for each file and checks if there is already an entry for this filename. If the file with this metadata matches exactly the newest version of the file metadata stored in Dat, then this file will be skipped (no change).
+Dat acts as a one-to-one mirror of the state of a folder and all its contents.
+When importing files, Dat grabs the filesystem metadata for each file and checks if there is already an entry for this filename.
+If the file with this metadata matches exactly the newest version of the file metadata stored in Dat, then this file will be skipped (no change).
 
 If the metadata differs or does not exist, then this new metadata entry will be appended as the new 'latest' version for this file in the append-only SLEEP metadata content register.
 
 ### Content Versioning
 
-The metadata only tells you if or when a file is changed, not how it changed. In addition to the metadata, Dat tracks changes in the content in a similar manner.
+The metadata only tells you if or when a file is changed, not how it changed.
+In addition to the metadata, Dat tracks changes in the content in a similar manner.
 
-The default storage system used in Dat stores the files as files. This has the advantage of being very straightforward for users to understand, but the downside of not storing old versions of content by default.
+The default storage system used in Dat stores the files as files.
+This has the advantage of being very straightforward for users to understand, but the downside of not storing old versions of content by default.
 
-In contrast to other version control systems, like Git, Dat only stores the current set of files, not older versions. Git, for example, stores all previous content versions and all previous metadata versions in the `.git` folder. But Dat is designed for larger datasets.
+In contrast to other version control systems, like Git, Dat only stores the current set of files, not older versions.
+Git, for example, stores all previous content versions and all previous metadata versions in the `.git` folder. But Dat is designed for larger datasets.
 
-Storing all history on content could easily fill up the users' hard drive. Dat has multiple storage modes based on usage. With Dat's dynamic storage, you can store the content history on a local external hard drive or on a remote server (or both!).
+Storing all history on content could easily fill up the users' hard drive.
+Dat has multiple storage modes based on usage.
+With Dat's dynamic storage, you can store the content history on a local external hard drive or on a remote server (or both!).
 
 ## Dat Privacy
 
-Files shared with Dat are encrypted (using the read key) so *only* users with your unique read key can access your files. The read key acts as a kind of password meaning, generally, you should assume *anyone* with the read key will have access to your files.
+Files shared with Dat are encrypted (using the read key) so *only* users with your unique read key can access your files.
+The read key acts as a kind of password meaning, generally, you should assume *anyone* with the read key will have access to your files.
 
 The read key allows users to download, and re-share, your files, whether you intended them to have the read key or not (with some hand waiving assumptions about them being able to connect to you, which can be limited, see more in [security & privacy faq](faq#security-and-privacy)).
 
-Make sure you are thoughtful about who you share read keys with and how. Dat ensures read key cannot be intercepted through the Dat network. If you share your read key over other channels, ensure the privacy & security matches or exceeds your data security needs. We try to limit times when Dat displays full read key to avoid accidental sharing.
+Make sure you are thoughtful about who you share read keys with and how.
+Dat ensures read key cannot be intercepted through the Dat network.
+If you share your read key over other channels, ensure the privacy & security matches or exceeds your data security needs.
+We try to limit times when Dat displays full read key to avoid accidental sharing.
 
 ## dat:// read keys
 
 Dat read keys have some special properties that are helpful to understand.
 
-Traditionally, http links point to a specific server, e.g. datproject.org's server, and/or a specific resource on that server. Unfortunately, links often break or the content changes without notification (this makes it impossible to cite `nytimes.com`, for example, because the link is meaningless without a reference to what content was there at citation time). Dat read keys, on the other hand, never change. You can update data in a dat and use the same link to download the changes.
+Traditionally, http links point to a specific server, e.g. datproject.org's server, and/or a specific resource on that server.
+Unfortunately, links often break or the content changes without notification (this makes it impossible to cite `nytimes.com`, for example, because the link is meaningless without a reference to what content was there at citation time).
+Dat read keys, on the other hand, never change.
+You can update data in a dat and use the same link to download the changes.
 
 Here is an example dat read key:
 
@@ -63,18 +98,23 @@ What is with the weird long string of characters? Let's break it down!
 
 **`dat://` - the protocol**
 
-The first part of the read key is the link protocol, Dat (read about the Dat protocol at [datprotocol.com](http://www.datprotocol.com)). The protocol describes what "language" the read key is in and what type of applications can open it. You do not always need this part with Dat but it is helpful context.
+The first part of the read key is the link protocol, Dat (read about the Dat protocol at [datprotocol.com](http://www.datprotocol.com)).
+The protocol describes what "language" the read key is in and what type of applications can open it.
+You do not always need this part with Dat but it is helpful context.
 
 **`ff34725120b2f3c5bd5028e4f61d14a45a22af48a7b12126d5d588becde88a93` - the unique identifier**
 
-The second part of the read key is a 64-character hex strings ([ed25519 public-keys](https://ed25519.cr.yp.to/) to be precise). Each Dat archive gets a public read key to identify it. With the hex string as a read key we can do a few things:
+The second part of the read key is a 64-character hex strings ([ed25519 public-keys](https://ed25519.cr.yp.to/) to be precise).
+Each Dat archive gets a public read key to identify it.
+With the hex string as a read key we can do a few things:
 
 1. Encrypt the data transfer
 2. Create a persistent identifier, an ID that never changes, even as file are updated (as opposed to a checksum which is based on the file contents).
 
 **`dat://ff34725120b2f3c5bd5028e4f61d14a45a22af48a7b12126d5d588becde88a93`**
 
-All together, the read keys can be thought of similarly to a web URL, as a place to get content, but with some extra special properties. When you download a dat:
+All together, the read keys can be thought of similarly to a web URL, as a place to get content, but with some extra special properties.
+When you download a dat:
 
 1. You do not have to worry about where the files are stored.
 2. You can always get the latest files available.

--- a/docs/learn-more-dat-protocol.md
+++ b/docs/learn-more-dat-protocol.md
@@ -4,9 +4,11 @@ title: More About the Dat Protocol
 sidebar_label: The dat:// Protocol
 ---
 
-Dat is a protocol for sharing data between computers. By making sure changes in data are transparent, everyone receives only the data they want, and connecting computers directly (rather than using a cloud server), Dat powers communities building next-generation Web.
+Dat is a protocol for sharing data between computers.
+By making sure changes in data are transparent, everyone receives only the data they want, and connecting computers directly (rather than using a cloud server), Dat powers communities building next-generation Web.
 
-The *Dat Project* helps shepherd community efforts surrounding the Dat protocol. Find more information about the specifications, Dat Protocol working group, and Dat governance:
+The *Dat Project* helps shepherd community efforts surrounding the Dat protocol.
+Find more information about the specifications, Dat Protocol working group, and Dat governance:
 
 * [Dat Protocol Specifications](https://www.datprotocol.com/)
 * [How Dat Works](https://datprotocol.github.io/how-dat-works/)

--- a/docs/learn-more-ecosystem.md
+++ b/docs/learn-more-ecosystem.md
@@ -3,9 +3,12 @@ id: dat-ecosystem
 title: Open Source Ecosystem
 ---
 
-We have built and contributed to a variety of modules that support our work on Dat as well as the larger data and code ecosystem. Feel free to go deeper and see the implementations we are using in the [Dat command-line tool](https://github.com/datproject/dat) and the [Dat Desktop](https://github.com/datproject/dat-desktop).
+We have built and contributed to a variety of modules that support our work on Dat as well as the larger data and code ecosystem.
+Feel free to go deeper and see the implementations we are using in the [Dat command-line tool](https://github.com/datproject/dat) and the [Dat Desktop](https://github.com/datproject/dat-desktop).
 
-Dat embraces the Unix philosophy: a modular design with composable parts. All of the pieces can be replaced with alternative implementations as long as they implement the abstract API. We believe this creates better end-user software, but more importantly, will create more sustainable and impactful open source tools.
+Dat embraces the Unix philosophy: a modular design with composable parts.
+All of the pieces can be replaced with alternative implementations as long as they implement the abstract API.
+We believe this creates better end-user software, but more importantly, will create more sustainable and impactful open source tools.
 
 ## User Software
 
@@ -37,4 +40,3 @@ These modules are community-driven and can be used to implement a variety of dis
 * [kappa-db](https://github.com/kappa-db) - Small core database for multiwriter kappa architectures.
 * [hypermerge](https://github.com/automerge/hypermerge#readme) - CRDT for merging multiple hypercore feeds.
 * [mirror-folder](https://github.com/mafintosh/mirror-folder) - Mirror a folder to another folder, supports hyperdrive and live file watching.
-

--- a/docs/learn-more-security.md
+++ b/docs/learn-more-security.md
@@ -5,43 +5,63 @@ title: Understanding Dat Privacy
 
 ### Can other users tell what I am downloading? 
 
-Users only connect to other users with the same dat read key. Anyone with a dat read key can see other users that are sharing that read key and their IP addresses.
+Users only connect to other users with the same dat read key.
+Anyone with a dat read key can see other users that are sharing that read key and their IP addresses.
 
-We are thinking more about how to ensure reader privacy. See [this blog post](https://blog.datproject.org/2016/12/12/reader-privacy-on-the-p2p-web/) for more discussion.
+We are thinking more about how to ensure reader privacy.
+See [this blog post](https://blog.datproject.org/2016/12/12/reader-privacy-on-the-p2p-web/) for more discussion.
 
 ### Is data shared over Dat encrypted?
 
-Yes, data shared over Dat is encrypted in transit using the read key (Dat read key). When you share a Dat, you must share the read key with another user so they can download it. We use that key on both ends to encrypt the data so both users can read the data but we can ensure the data is not transferred over the internet without encryption.
+Yes, data shared over Dat is encrypted in transit using the read key (Dat read key).
+When you share a Dat, you must share the read key with another user so they can download it.
+We use that key on both ends to encrypt the data so both users can read the data but we can ensure the data is not transferred over the internet without encryption.
 
 ### Is it possible to discover read keys via man-in-the-middle?
 
-One of the key elements of Dat privacy is that the read key is never used in any discovery network. The read key is hashed, creating the discovery key. Whenever peers attempt to connect to each other, they use the discovery key.
+One of the key elements of Dat privacy is that the read key is never used in any discovery network.
+The read key is hashed, creating the discovery key.
+Whenever peers attempt to connect to each other, they use the discovery key.
 
 Data is encrypted using the read key, so it is important that this key stays secure.
 
 ### Can anyone download my data? What if I don't share the key with anyone?
 
-Only someone with the read key can download data for Dat. It is the responsibility of the user that the Dat read key is only shared with people who should access the data. The key is never sent over the network via Dat. We do not track keys centrally. It is almost impossible for keys to overlap (and thus to guess keys).
+Only someone with the read key can download data for Dat.
+It is the responsibility of the user that the Dat read key is only shared with people who should access the data.
+The key is never sent over the network via Dat.
+We do not track keys centrally.
+It is almost impossible for keys to overlap (and thus to guess keys).
 
 ### How can I create stronger privacy protections for my data?
 
-As long as the read key isn't shared outside of your team, the content will be secure (though the IP addresses and discovery key may become known). You can take a few steps further to improve privacy (generally at the cost of ease of use):
+As long as the read key isn't shared outside of your team, the content will be secure (though the IP addresses and discovery key may become known).
+You can take a few steps further to improve privacy (generally at the cost of ease of use):
 
 1. Disable bittorrent DHT discovery (using only DNS discovery), use `--no-dht` flag in CLI.
 2. Whitelist IP addresses
 3. Run your own discovery servers
 4. Encrypt contents before adding to dat (content is automatically encrypted in transit but this would also require decrypting after arrival).
 
-Only some of these options can be done in the current command line tool. Feel free to PR options to make these easier to configure!
+Only some of these options can be done in the current command line tool.
+Feel free to PR options to make these easier to configure!
 
 ### How does Dat make sure I download the correct content?
 
-Dat uses the concept of a [Merkle tree](https://en.wikipedia.org/wiki/Merkle_tree) to make sure content is not tampered with. When content is added to a Dat we  cryptographically fingerprint it and add it to the tree. On download, we can use the tree to make sure the content has not changed and the parent hashes match.
+Dat uses the concept of a [Merkle tree](https://en.wikipedia.org/wiki/Merkle_tree) to make sure content is not tampered with.
+When content is added to a Dat we  cryptographically fingerprint it and add it to the tree.
+On download, we can use the tree to make sure the content has not changed and the parent hashes match.
 
 ### How does Dat help to improve transparency?
 
-Dat uses an append-only to track changes over time. An append-only log shows all of the changes for a given Dat since it was shared. We use this for version control but it can also bolster transparency for a dataset. Any changes to a dataset will be tracked and you can see what changed and when.
+Dat uses an append-only to track changes over time. An append-only log shows all of the changes for a given Dat since it was shared.
+We use this for version control but it can also bolster transparency for a dataset.
+Any changes to a dataset will be tracked and you can see what changed and when.
 
 ### Privacy and Security Versus Bittorrent
 
-As a peer to peer network, Dat faces similar privacy risks as Bittorrent. When you download a dataset, your IP address is exposed to the users sharing that dataset. This may lead to honeypot servers collecting IP addresses, as we've seen in Bittorrent. However, with dataset sharing we can create a web of trust model where specific institutions are trusted as primary sources for datasets, diminishing the sharing of IP addresses. [Read more](https://blog.datproject.org/2016/12/12/reader-privacy-on-the-p2p-web/) about reader privacy in the p2p web.
+As a peer to peer network, Dat faces similar privacy risks as Bittorrent.
+When you download a dataset, your IP address is exposed to the users sharing that dataset.
+This may lead to honeypot servers collecting IP addresses, as we've seen in Bittorrent.
+However, with dataset sharing we can create a web of trust model where specific institutions are trusted as primary sources for datasets, diminishing the sharing of IP addresses.
+[Read more](https://blog.datproject.org/2016/12/12/reader-privacy-on-the-p2p-web/) about reader privacy in the p2p web.

--- a/docs/learn-more-terms.md
+++ b/docs/learn-more-terms.md
@@ -3,28 +3,34 @@ id: terms
 title: Dat Terminology
 ---
 
-
 Terms use in the Dat ecosystem.
 
 ### dat, Dat archive, archive
 
-A dat, or Dat archive, is a set of files and dat metadata. A dat folder can contain files of any type, which can be synced to other users. A dat has a read key used to share with other people.
+A dat, or Dat archive, is a set of files and dat metadata.
+A dat folder can contain files of any type, which can be synced to other users.
+A dat has a read key used to share with other people.
 
 When you create a dat with the command line and Node.js API, you're creating a `.dat` folder to hold the metadata and the dat keys (a read and write key).
 
 ### Write Key
 
-Write keys are the private part of a key pair. Users that have the write key are able to write updates to a dat.
+Write keys are the private part of a key pair.
+Users that have the write key are able to write updates to a dat.
 
-With the Dat CLI and Desktop application, read keys are stored in a dat folder in your home directory, `~/.dat/secret_keys`. It is important to back these up if you get a new computer.
+With the Dat CLI and Desktop application, read keys are stored in a dat folder in your home directory, `~/.dat/secret_keys`.
+It is important to back these up if you get a new computer.
 
 ### Writer
 
-User who can write to a Dat archive. This user has the write key, allowing them to write data. Currently, dats are single-writer.
+User who can write to a Dat archive.
+This user has the write key, allowing them to write data.
+Currently, dats are single-writer.
 
 ### Collaborator
 
-User who are granted read access to a Dat archive by the owner. A collaborator can access a Dat archive if the owner or another collaborator sends the Dat link.
+User who are granted read access to a Dat archive by the owner.
+A collaborator can access a Dat archive if the owner or another collaborator sends the Dat link.
 
 In the future, users will be able to grant collaborators write access to the Dat archive, allowing them to modify and create files in the archive.
 
@@ -36,19 +42,26 @@ A group of peers that want or have downloaded data for a Dat archive and are con
 
 ### Distributed Web
 
-In a Distributed Web (P2P) model, those who are downloading the data also provide bandwidth and storage to share it. Instead of one server, we have many. The more people or organizations that are involved in the Distributed Web, the more redundant, safe, and fast it will become.
+In a Distributed Web (P2P) model, those who are downloading the data also provide bandwidth and storage to share it.
+Instead of one server, we have many.
+The more people or organizations that are involved in the Distributed Web, the more redundant, safe, and fast it will become.
 
-Currently, the Web is centralized: if someone controls the hardware or the communication line, then they control all the uses of that website. [Read more here](http://brewster.kahle.org/2015/08/11/locking-the-web-open-a-call-for-a-distributed-web-2/).
+Currently, the Web is centralized: if someone controls the hardware or the communication line, then they control all the uses of that website.
+[Read more here](http://brewster.kahle.org/2015/08/11/locking-the-web-open-a-call-for-a-distributed-web-2/).
 
 ### Peer to Peer (P2P)
 
-A P2P software program searches for other connected computers on a P2P network to locate the desired content. The peers of such networks are end-user computer systems that are interconnected via the Internet.
+A P2P software program searches for other connected computers on a P2P network to locate the desired content.
+The peers of such networks are end-user computer systems that are interconnected via the Internet.
 
 In Dat, peers only connect if they both have the same Dat link.
 
 ### Store / Storage Provider
 
-Distributed web content needs to have at least one peer in the network which has a copy of the content in order for new peers to be able to download it. Stores or storage providers let users send their Dat read key to their server and they will set up a peer that they guarantee will always be online. [Hashbase](https://hashbase.io/) is a popular storage provider, and you can host your own using [dat-store](https://www.npmjs.com/dat-store) or [Homebase](https://github.com/beakerbrowser/homebase/)
+Distributed web content needs to have at least one peer in the network which has a copy of the content in order for new peers to be able to download it.
+
+Stores or storage providers let users send their Dat read key to their server and they will set up a peer that they guarantee will always be online.
+[Hashbase](https://hashbase.io/) is a popular storage provider, and you can host your own using [dat-store](https://www.npmjs.com/dat-store) or [Homebase](https://github.com/beakerbrowser/homebase/)
 
 ### Beaker
 
@@ -58,27 +71,35 @@ The [Beaker Browser](https://beakerbrowser.com/) is an experimental p2p browser 
 
 ### SLEEP
 
-SLEEP is the the on-disk format that Dat produces and uses. It is a set of 9 files that hold all of the metadata needed to list the contents of a Dat repository and verify the integrity of the data you receive.
+SLEEP is the the on-disk format that Dat produces and uses.
+It is a set of 9 files that hold all of the metadata needed to list the contents of a Dat repository and verify the integrity of the data you receive.
 
-The acronym SLEEP is a slumber related pun on REST and stands for Syncable Lightweight Event Emitting Persistence. The Event Emitting part refers to how SLEEP files are append-only in nature, meaning they grow over time and new updates can be subscribed to as a realtime feed of events through the Dat protocol.
+The acronym SLEEP is a slumber related pun on REST and stands for Syncable Lightweight Event Emitting Persistence.
+The Event Emitting part refers to how SLEEP files are append-only in nature, meaning they grow over time and new updates can be subscribed to as a realtime feed of events through the Dat protocol.
 
 Read the full [SLEEP specification](https://github.com/datproject/docs/blob/master/papers/dat-paper.md#3-sleep-specification) in the dat whitepaper.
 
 ### Key
 
-A 32-bit hash that uniquely represents a feed. All hypercore feeds have keys. The metadata key is used as the read key for an archive.
+A 32-bit hash that uniquely represents a feed.
+All hypercore feeds have keys.
+The metadata key is used as the read key for an archive.
 
 ### Read key
 
-The read key is the key that is used as the Dat link. Messages are signed using the read key, allowing write access to feeds. The owner is the only user with the read key.
+The read key is the key that is used as the Dat link.
+Messages are signed using the read key, allowing write access to feeds.
+The owner is the only user with the read key.
 
 ### Discovery Key
 
-The discovery key is a hashed read key. The discovery key is used to find peers on the read key without exposing the original read key to network.
+The discovery key is a hashed read key.
+The discovery key is used to find peers on the read key without exposing the original read key to network.
 
 ### Feed
 
-A feed is a term we use interchangeably with the term "append-only log". It’s the lowest level component of Dat. For each Dat, there are two feeds - the metadata and the content.
+A feed is a term we use interchangeably with the term "append-only log".
+It’s the lowest level component of Dat. For each Dat, there are two feeds - the metadata and the content.
 
 Feeds are created with hypercore.
 
@@ -86,34 +107,49 @@ Feeds are created with hypercore.
 
 Like an HTTP header, the metadata contains a pointer to the contents of Dat and the file list.
 
-The metadata is a hypercore feed. The first entry in the metadata feed is the key for the content feed.
+The metadata is a hypercore feed.
+The first entry in the metadata feed is the key for the content feed.
 
 ### Content Feed
 
-The content feed is a hypercore feed containing the file contents for a Dat archive. The content feed together with a metadata feed make a Dat archive.
+The content feed is a hypercore feed containing the file contents for a Dat archive.
+The content feed together with a metadata feed make a Dat archive.
 
 ### Version
 
-Internally every dat data-structure is composed of append-only logs or feeds (hypercores). Any time an entry is appended to the log, a new version is created. The version is identified according to the semantics of the data-structure. In the case of single-writer hyperdrive, it's currently being identified by the metadata log's latest message number.
+Internally every dat data-structure is composed of append-only logs or feeds (hypercores).
+Any time an entry is appended to the log, a new version is created.
+The version is identified according to the semantics of the data-structure.
+In the case of single-writer hyperdrive, it's currently being identified by the metadata log's latest message number.
 
 ### Sparse
 
-When you load an archive, by default you only load the parts that are necessary. This is called `sparse` replication and is passed in as a flag when initializing the archive. For situations where you want to download the entire history of an archive, `sparse` is set to `false`.
+When you load an archive, by default you only load the parts that are necessary.
+This is called `sparse` replication and is passed in as a flag when initializing the archive.
+For situations where you want to download the entire history of an archive, `sparse` is set to `false`.
 
 ### Checkout
 
-Sometimes you want to load content from a Dat archive at a specific point in it's history. For that you need to checkout a given version which will ignore any newer changes and show you want the archive looked that at that version.
+Sometimes you want to load content from a Dat archive at a specific point in it's history.
+For that you need to checkout a given version which will ignore any newer changes and show you want the archive looked that at that version.
 
 ### Hyperdrive
 
-[Hyperdrive](https://github.com/mafintosh/hyperdrive) is peer to peer directories. We built hyperdrive to efficiently share scientific data in real time between research institutions. Hyperdrive handles the distribution of files while encrypting data transfer and ensuring content integrity. Hyperdrive creates append-only logs for file changes allow users to download partial datasets and to create versioned data. Hyperdrive is built on hypercore.
+[Hyperdrive](https://github.com/mafintosh/hyperdrive) is peer to peer directories.
+We built hyperdrive to efficiently share scientific data in real time between research institutions.
+Hyperdrive handles the distribution of files while encrypting data transfer and ensuring content integrity.
+Hyperdrive creates append-only logs for file changes allow users to download partial datasets and to create versioned data. Hyperdrive is built on hypercore.
 
 Archives created with hyperdrive are made with two feeds, one for the metadata and one for the content.
 
 ### Hypercore
 
-[Hypercore](https://github.com/mafintosh/hypercore) is a protocol and network for distributing and replicating feeds of binary data. This creates an efficient gossip network where latency is reduced to a minimum. Hypercore is an eventually consistent, highly available, partition tolerant system.
+[Hypercore](https://github.com/mafintosh/hypercore) is a protocol and network for distributing and replicating feeds of binary data.
+This creates an efficient gossip network where latency is reduced to a minimum.
+Hypercore is an eventually consistent, highly available, partition tolerant system.
 
 ### Bootstrapping
 
-In order to discover peers in a P2P network, you must first discover some initial peers to connect to. This is know as Bootstrapping and is done by Dat whenever you load into a swarm. The default bootstrap IPs that Dat uses can be found in the [dat-swarm-defaults](https://github.com/datproject/dat-swarm-defaults/blob/master/index.js) module.
+In order to discover peers in a P2P network, you must first discover some initial peers to connect to.
+This is know as Bootstrapping and is done by Dat whenever you load into a swarm.
+The default bootstrap IPs that Dat uses can be found in the [dat-swarm-defaults](https://github.com/datproject/dat-swarm-defaults/blob/master/index.js) module.

--- a/docs/usingdat-browser.md
+++ b/docs/usingdat-browser.md
@@ -3,19 +3,28 @@ id: browser-intro
 title: Browser Dat
 ---
 
-**We've just released a NEW!! version of [dat-js](https://github.com/datproject/dat-js). Take a look and let us know how you use it!**
+**We've just released a NEW!! version of [dat-js](https://github.com/datproject/dat-js).
+Take a look and let us know how you use it!**
 
-Dat is written in JavaScript, so naturally, it can work entirely in the browser! The great part about this is that as more peers connect to each other in their client, the site assets will be shared between users rather hitting any server.
+Dat is written in JavaScript, so naturally, it can work entirely in the browser!
+The great part about this is that as more peers connect to each other in their client, the site assets will be shared between users rather hitting any server.
 
-This approach is similar to that used in Feross' [Web Torrent](http://webtorrent.io). The difference is that Dats can be rendered live and read dynamically, whereas BitTorrent links are static. The original owner of a Dat can update the files in the directory and all peers will receive the updates automatically.
+This approach is similar to that used in Feross' [Web Torrent](http://webtorrent.io).
+The difference is that Dats can be rendered live and read dynamically, whereas BitTorrent links are static.
+The original owner of a Dat can update the files in the directory and all peers will receive the updates automatically.
 
 ## Connecting to non-browser peers
 
-dat-js primarily uses WebRTC, so it prioritizes connections to other browser peers that are also using WebRTC. All other Dat applications use non-WebRTC protocols ([see this FAQ for more info](getting-started-faq.md)). Non-browser clients can connect dats peer-to-peer via webrtc modules, such as [electron-webrtc](https://github.com/mappum/electron-webrtc), or use proxies via websockets, http, or other client-server protocols.
+dat-js primarily uses WebRTC, so it prioritizes connections to other browser peers that are also using WebRTC.
+All other Dat applications use non-WebRTC protocols ([see this FAQ for more info](getting-started-faq.md)).
+Non-browser clients can connect dats peer-to-peer via webrtc modules, such as [electron-webrtc](https://github.com/mappum/electron-webrtc), or use proxies via websockets, http, or other client-server protocols.
 
-In order for the dat-js library to connect to clients that aren't in the browser, we recommend using [dat-gateway](https://github.com/garbados/dat-gateway/). Deploy your own gateway if you expect a lot of traffic to your application.
+In order for the dat-js library to connect to clients that aren't in the browser, we recommend using [dat-gateway](https://github.com/garbados/dat-gateway/).
+Deploy your own gateway if you expect a lot of traffic to your application.
 
-A gateway works by having the client open a [websocket](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket) to the gateway, and have the gateway reach out to the rest of the dat network in order to fetch data from peers and send it down the websocket connection to dat-js. The gateway acts as a fallback and only gets used after dat-js has tried to connect to WebRTC peers first. This reduces gateway bandwidth constraints and keeps most of the traffic peer to peer.
+A gateway works by having the client open a [websocket](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket) to the gateway, and have the gateway reach out to the rest of the dat network in order to fetch data from peers and send it down the websocket connection to dat-js.
+The gateway acts as a fallback and only gets used after dat-js has tried to connect to WebRTC peers first.
+This reduces gateway bandwidth constraints and keeps most of the traffic peer to peer.
 
 There is an example gateway deployed at [gateway.mauve.moe](https://gateway.mauve.moe/).
 
@@ -24,6 +33,7 @@ OK, now for the goods.
 ## Install
 
 Embed the following script [dat.min.js](https://bundle.run/dat-js@8) on the page:
+
 ```html
 <script type="text/javascript" src="dat.min.js"></script>
 ```
@@ -66,10 +76,11 @@ Then include a script tag pointing at your `bundle.js`:
 <script type="text/javascript" src="bundle.js"></script>
 ```
 
-
 #### Getting data from a remote dat
 
-You can load a Dat archive using it's `read key`. Dat-js will reach out to the P2P network and start loading the metadata into memory. From there you can invoke [hyperdrive](https://www.npmjs.com/package/hyperdrive) methods to read the data.
+You can load a Dat archive using it's `read key`.
+Dat-js will reach out to the P2P network and start loading the metadata into memory.
+From there you can invoke [hyperdrive](https://www.npmjs.com/package/hyperdrive) methods to read the data.
 
 ```js
 var Dat = require('dat-js')
@@ -87,7 +98,8 @@ readStream.on('data', console.log)
 
 #### Persisting a created dat and loading it from storage
 
-By default, when you create a new Dat archive with Dat-js, it will be erased after you refresh the page. In order to keep it around for the next time the user loads the page, you need to make sure to enable the `persist` flag, and save a copy of the `url` read key to someplace like [localStorage](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage).
+By default, when you create a new Dat archive with Dat-js, it will be erased after you refresh the page.
+In order to keep it around for the next time the user loads the page, you need to make sure to enable the `persist` flag, and save a copy of the `url` read key to someplace like [localStorage](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage).
 
 ```js
 var Dat = require('dat-js')
@@ -133,14 +145,20 @@ Creates a new dat object. The options passed here will be default for any dats c
 
 ### `dat.get(url, [options])`
 
-Adds a new dat with the given url. Joins the appropriate swarm for that url and begins to upload and download data. If the dat was already added, it will return the existing instance. One gotcha is that dat-js doesn't support DNS resolution yet. As such you'll need to use the actual archive key for loading websites. `dat-js` adds a `url` field to the archive, which contains the [read key](https://docs.datproject.org/docs/concepts#distributed-network), but you can see the rest of the APIs available in the [hyperdrive](https://www.npmjs.com/package/hyperdrive) docs.
+Adds a new dat with the given url.
+Joins the appropriate swarm for that url and begins to upload and download data.
+If the dat was already added, it will return the existing instance.
+One gotcha is that dat-js doesn't support DNS resolution yet.
+As such you'll need to use the actual archive key for loading websites.
+`dat-js` adds a `url` field to the archive, which contains the [read key](https://docs.datproject.org/docs/concepts#distributed-network), but you can see the rest of the APIs available in the [hyperdrive](https://www.npmjs.com/package/hyperdrive) docs.
 
  * `url`: Either a `dat://` url or just the public key in string form.
  * `options`: These options will override any options given in the Dat constructor.
 
 ### `dat.create([options])`
 
-Creates a new dat, wait for it to be `ready` before trying to access the url. Make sure to save the archive `url` somewhere and enable `persist: true` so you can access it again later!
+Creates a new dat, wait for it to be `ready` before trying to access the url.
+Make sure to save the archive `url` somewhere and enable `persist: true` so you can access it again later!
 
 * `options`: These options will override any options given in the Dat constructor.
 
@@ -167,9 +185,11 @@ Fired when dat is finished closing, including swarm and database.
 
 ## Downloading everything or only what you need
 
-You might be asking 'Is it possible to index into a subset of a dat dataset?' Most datasets are too large for browsers, and we probably only want a subset of them.
+You might be asking 'Is it possible to index into a subset of a dat dataset?'
+Most datasets are too large for browsers, and we probably only want a subset of them.
 
-You can do this by using `sparse` mode, which makes it only download content that the peer asks for. This is actually enabled by default and you can opt-into downloading the entire archive by passing `{sparse: false}` when you create the dat:
+You can do this by using `sparse` mode, which makes it only download content that the peer asks for.
+This is actually enabled by default and you can opt-into downloading the entire archive by passing `{sparse: false}` when you create the dat:
 
 ```js
 var Dat = require('dat-js')
@@ -212,7 +232,10 @@ swarm.on('peer', function (conn) {
 })
 ```
 
-That's it. Now you are serving a dat-compatible hyperdrive from the browser. In another browser tab, you can connect to the swarm and download the data by using the same code as above. Just make sure to reference the archive you created before by using `archive.key` as the first argument:
+That's it.
+Now you are serving a dat-compatible hyperdrive from the browser.
+In another browser tab, you can connect to the swarm and download the data by using the same code as above.
+Just make sure to reference the archive you created before by using `archive.key` as the first argument:
 
 -->
 
@@ -220,23 +243,30 @@ That's it. Now you are serving a dat-compatible hyperdrive from the browser. In 
 
 Hyperdrive is the underlying database that runs dat.
 
-Hyperdrive will save the metadata (small) and the content (potentially large) separately. You can control where both of these are saved and how they are retrieved. These tweaks have huge impact on performance, stability, and user experience, so it's important to understand the tradeoffs.
+Hyperdrive will save the metadata (small) and the content (potentially large) separately.
+You can control where both of these are saved and how they are retrieved.
+These tweaks have huge impact on performance, stability, and user experience, so it's important to understand the tradeoffs.
 
-There are a million different ways to store and retrieve data in the browser, and all have their pros and cons depending on the use case. We've compiled a variety of examples here to try to make it as clear as possible.
+There are a million different ways to store and retrieve data in the browser, and all have their pros and cons depending on the use case.
+We've compiled a variety of examples here to try to make it as clear as possible.
 
-You can pass in the specific implementation with the `db` parameter when initializing dat-js. By default, dat-js uses [random-access-memory](https://www.npmjs.com/package/random-access-memory) which is fast, but gets cleared when you refresh the page.
+You can pass in the specific implementation with the `db` parameter when initializing dat-js.
+By default, dat-js uses [random-access-memory](https://www.npmjs.com/package/random-access-memory) which is fast, but gets cleared when you refresh the page.
 
 There are many different ways to piece modules together to create the storage infrastructure for a hyperdrive -- here are some tested examples:
 
 ### Writing large files from the filesystem to the browser
 
-File writes are limited to the available memory on the machine. Files are buffered (read: copied) *into memory* while being written to the hyperdrive instance. This isn't ideal, but works as long as file sizes stay below system RAM limits.
+File writes are limited to the available memory on the machine.
+Files are buffered (read: copied) *into memory* while being written to the hyperdrive instance.
+This isn't ideal, but works as long as file sizes stay below system RAM limits.
 
 To fix this problem, you can use [random-access-file-reader](https://github.com/mafintosh/random-access-file-reader) to read the files directly from the filesystem instead of buffering them into memory.
 
 ### Writing files to IndexedDB in the browser
 
-[IndexedDB](https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API) is a low-level key-value database that's supported by all the major browsers. It can be used to persist data for your dat archives across page refreshes and tabs using the [random-access-idb](https://www.npmjs.com/package/random-access-idb) module.
+[IndexedDB](https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API) is a low-level key-value database that's supported by all the major browsers.
+It can be used to persist data for your dat archives across page refreshes and tabs using the [random-access-idb](https://www.npmjs.com/package/random-access-idb) module.
 
 You can decide to have dat archives persist to memory by default and only load certain ones through idb:
 
@@ -253,7 +283,9 @@ var persistedRepo = dat.get(url, {
 
 ## Get in touch!
 
-Come over to our community channels and ask a question. It's probably a good one and we should cover it in the documentation. Thanks for trying it out, and PRs always welcome!
+Come over to our community channels and ask a question.
+It's probably a good one and we should cover it in the documentation.
+Thanks for trying it out, and PRs always welcome!
 
 [![#dat IRC channel on freenode](https://img.shields.io/badge/irc%20channel-%23dat%20on%20freenode-blue.svg)](http://webchat.freenode.net/?channels=dat)
 [![datproject/discussions](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/datproject/discussions?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)

--- a/docs/usingdat-cli.md
+++ b/docs/usingdat-cli.md
@@ -3,26 +3,33 @@ id: cli-intro
 title: Command Line
 ---
 
-Share, download, and backup files with the command line! Automatically sync changes to datasets. Never worry about manually transferring files again.
+Share, download, and backup files with the command line!
+Automatically sync changes to datasets.
+Never worry about manually transferring files again.
 
 Have questions or need some guidance?
 You can chat with us on [Gitter][gitter-chat]!
 
 ## Getting Started
 
-Dat's unique design works wherever you store your data. You can create a new dat from any folder on your computer.
+Dat's unique design works wherever you store your data.
+You can create a new dat from any folder on your computer.
 
-A dat is some files from your computer and a `.dat` folder. Each dat has a unique `dat://` link. With your dat link, other users can download your files and live sync any updates.
+A dat is some files from your computer and a `.dat` folder. Each dat has a unique `dat://` link.
+With your dat link, other users can download your files and live sync any updates.
 
 ### Sharing Data
 
-You can start sharing your files with a single command. Unlike `git`, you do not have to initialize a repository first, `dat share` will do that for you:
+You can start sharing your files with a single command.
+Unlike `git`, you do not have to initialize a repository first, `dat share` will do that for you:
 
 ```
 dat share <dir>
 ```
 
-Use `dat share` to create a dat and sync your files from your computer to other users. Dat scans your files inside `<dir>`, creating metadata in `<dir>/.dat`. Dat stores the public link, version history, and file information inside the dat folder.
+Use `dat share` to create a dat and sync your files from your computer to other users.
+Dat scans your files inside `<dir>`, creating metadata in `<dir>/.dat`.
+Dat stores the public link, version history, and file information inside the dat folder.
 
 ![animation demonstrating the "dat share" command](assets/cli-share.gif)
 
@@ -32,7 +39,10 @@ Use `dat share` to create a dat and sync your files from your computer to other 
 dat clone dat://<link> <download-dir>
 ```
 
-Use `dat clone` to download files from a remote computer sharing files with Dat. This will download the files from `dat://<link>` to your `<download-dir>`. The download exits after it completes but you can continue to update the files later after the clone is done. Use `dat pull` to update new files or `dat sync` to live sync changes.
+Use `dat clone` to download files from a remote computer sharing files with Dat.
+This will download the files from `dat://<link>` to your `<download-dir>`.
+The download exits after it completes but you can continue to update the files later after the clone is done.
+Use `dat pull` to update new files or `dat sync` to live sync changes.
 
 ![animation demonstrating the "dat clone" command](assets/cli-clone.gif)
 
@@ -52,9 +62,12 @@ To get started using Dat, you can try downloading a dat and then sharing a dat o
 
 #### Download Demo
 
-We made a demo folder just for this exercise. Inside the demo folder is a `dat.json` file and a gif. We shared these files via Dat and now you can download them with our dat key!
+We made a demo folder just for this exercise.
+Inside the demo folder is a `dat.json` file and a gif.
+We shared these files via Dat and now you can download them with our dat key!
 
-Similar to git, you can download somebody's dat by running `dat clone <link>`. You can also specify the directory:
+Similar to git, you can download somebody's dat by running `dat clone <link>`.
+You can also specify the directory:
 
 ```
 ❯ dat clone dat://778f8d955175c92e4ced5e4f5563f69bfec0c86cc6f670352c457943666fe639 ~/Downloads/dat-demo
@@ -68,15 +81,20 @@ dat sync complete.
 Version 4
 ```
 
-This will download our demo files to the `~/Downloads/dat-demo` folder. These files are being shared by a server over Dat (to ensure high availability) but you may connect to any number of users also hosting the content.
+This will download our demo files to the `~/Downloads/dat-demo` folder.
+These files are being shared by a server over Dat (to ensure high availability) but you may connect to any number of users also hosting the content.
 
 #### Sharing Demo
 
-Dat can share files from your computer to anywhere. If you have a friend going through this demo with you, try sharing to them! If not we'll see what we can do.
+Dat can share files from your computer to anywhere.
+If you have a friend going through this demo with you, try sharing to them!
+If not we'll see what we can do.
 
-Find a folder on your computer to share. Inside the folder can be anything, Dat can handle all sorts of files (Dat works with really big folders too!).
+Find a folder on your computer to share.
+Inside the folder can be anything, Dat can handle all sorts of files (Dat works with really big folders too!).
 
-First, you can create a new dat inside that folder. Using the `dat create` command also walks us through making a `dat.json` file:
+First, you can create a new dat inside that folder.
+Using the `dat create` command also walks us through making a `dat.json` file:
 
 ```
 ❯ dat create
@@ -85,13 +103,20 @@ You can turn any folder on your computer into a Dat.
 A Dat is a folder with some magic.
 ```
 
-This will create a new (empty) dat. Dat will print a link, share this link to give others access to view your files.
+This will create a new (empty) dat.
+Dat will print a link, share this link to give others access to view your files.
 
-Once we have our dat, run `dat share` to scan your files and sync them to the network. Share the link with your friend to instantly start downloading files.
+Once we have our dat, run `dat share` to scan your files and sync them to the network.
+Share the link with your friend to instantly start downloading files.
 
 #### Bonus HTTP Demo
 
-Dat makes it really easy to share live files on a HTTP server. This is a cool demo because we can also see how version history works! Serve dat files on HTTP with the `--http` option. For example, `dat sync --http`, serves your files to a HTTP website with live reloading and version history! This even works for dats you're downloading (add the `--sparse` option to only download files you select via HTTP). The default HTTP port is 8080.
+Dat makes it really easy to share live files on a HTTP server.
+This is a cool demo because we can also see how version history works!
+Serve dat files on HTTP with the `--http` option.
+For example, `dat sync --http`, serves your files to a HTTP website with live reloading and version history!
+This even works for dats you're downloading (add the `--sparse` option to only download files you select via HTTP).
+The default HTTP port is 8080.
 
 *Hint: Use `localhost:8080/?version=10` to view a specific version.*
 
@@ -102,7 +127,8 @@ Get started using Dat today with the `share` and `clone` commands or read below 
 The first time you run a command, a `.dat` folder is created to store the dat metadata.
 Once a dat is created, you can run all the commands inside that folder, similar to git.
 
-Dat keeps secret keys in the `~/.dat/secret_keys` folder. These are required to write to any dats you create.
+Dat keeps secret keys in the `~/.dat/secret_keys` folder.
+These are required to write to any dats you create.
 
 #### Creating a dat & dat.json
 
@@ -110,7 +136,8 @@ Dat keeps secret keys in the `~/.dat/secret_keys` folder. These are required to 
 dat create [<dir>]
 ```
 
-The create command prompts you to make a `dat.json` file and creates a new dat. Import the files with sync or share.
+The create command prompts you to make a `dat.json` file and creates a new dat.
+Import the files with sync or share.
 
 Optionally bypass Title and Description prompt:
 
@@ -156,18 +183,25 @@ Sync watches files for changes and imports updated files.
 
 #### Ignoring Files
 
-By default, Dat will ignore any files in a `.datignore` file, similar to git. Each file should be separated by a newline. Dat also ignores all hidden folders and files.
+By default, Dat will ignore any files in a `.datignore` file, similar to git.
+Each file should be separated by a newline.
+Dat also ignores all hidden folders and files.
 
-Dat uses [dat-ignore] to decide if a file should be ignored. Supports pattern wildcards (`/*.png`) and directory-wildcards (`/**/cache`).
+Dat uses [dat-ignore] to decide if a file should be ignored.
+Supports pattern wildcards (`/*.png`) and directory-wildcards (`/**/cache`).
 
 #### Selecting Files
 
-By default, Dat will download all files. If you want to only download a subset, you can create a `.datdownload` file which downloads only the files and folders specified. Each should be separated by a newline.
+By default, Dat will download all files.
+If you want to only download a subset, you can create a `.datdownload` file which downloads only the files and folders specified.
+Each should be separated by a newline.
 
 
 ### Downloading
 
-Start downloading by running the `clone` command. This creates a folder, downloads the content and metadata, and a `.dat` folder inside. Once you started the download, you can resume using `clone` or the other download commands.
+Start downloading by running the `clone` command.
+This creates a folder, downloads the content and metadata, and a `.dat` folder inside.
+Once you started the download, you can resume using `clone` or the other download commands.
 
 ```
 dat clone <link> [<dir>] [--temp]
@@ -178,7 +212,9 @@ This will create a folder with the key name if no folder is specified.
 
 #### Downloading via `dat.json` key
 
-You can use a `dat.json` file to clone also. This is useful when combining Dat and git, for example. To clone a dat you can specify the path to a folder containing a `dat.json`:
+You can use a `dat.json` file to clone also.
+This is useful when combining Dat and git, for example.
+To clone a dat you can specify the path to a folder containing a `dat.json`:
 
 ```
 git clone git@github.com:joehand/dat-clone-sparse-test.git
@@ -212,7 +248,9 @@ Download latest files and keep connection open to continue updating as remote so
 
 `dat keys` provides a few commands to help you move or backup your dats.
 
-Writing to a dat requires the secret key, stored in the `~/.dat` folder. You can export and import these keys between dats. First, clone your dat to the new location:
+Writing to a dat requires the secret key, stored in the `~/.dat` folder.
+You can export and import these keys between dats.
+First, clone your dat to the new location:
 
 * (original) `dat share`
 * (duplicate) `dat clone <link>`
@@ -319,7 +357,6 @@ Dat('/data', function (err, dat) {
 ```
 
 **[Read more][dat-node] about the JS usage provided via `dat-node`.**
-
 
 [Dat Project]: https://datproject.org
 [Code for Science & Society]: https://codeforscience.org

--- a/docs/usingdat-cli2.md
+++ b/docs/usingdat-cli2.md
@@ -3,7 +3,9 @@ id: cli-more
 title: Sharing files over HTTP
 ---
 
-The Dat command line comes with a built in HTTP server. This is a cool demo because we can also see how version history works! The `--http` option works for files you are sharing *or* downloading.
+The Dat command line comes with a built in HTTP server.
+This is a cool demo because we can also see how version history works!
+The `--http` option works for files you are sharing *or* downloading.
 
 (If you don't have dat command line installed, run `npm install -g dat`, or [see more info](getting-started-installation.md).)
 
@@ -20,7 +22,8 @@ Serving files over http at http://localhost:8080
 2 connections | Download 0 B/s Upload 0 B/s
 ```
 
-Now visit `http://localhost:8080` to see the files in your browser! The default http port is 8080. You should see a directory listing:
+Now visit `http://localhost:8080` to see the files in your browser!
+The default http port is 8080. You should see a directory listing:
 
 <img src="/assets/cli-http.png" alt="Dat HTTP viewer"/>
 
@@ -30,17 +33,22 @@ You can combine Dat's http support with our server tools to create a live updati
 
 ## Built-in Versioning
 
-As you may know, Dat automatically versions all files. The HTTP display is an easy way to view version history:
+As you may know, Dat automatically versions all files.
+The HTTP display is an easy way to view version history:
 
 **Use `localhost:8080/?version=2` to view a specific version.**
 
 ## Live reloading
 
-The Dat http viewer also comes with live reloading. If it detects a new version it will automatically reload with the new directory listing or page (as long as you aren't viewing a specific version in the url).
+The Dat http viewer also comes with live reloading.
+If it detects a new version it will automatically reload with the new directory listing or page (as long as you aren't viewing a specific version in the url).
 
 ## Sparse Downloading
 
-Dat supports *sparse*, or partial downloads, of datasets. This is really useful if you only want a single file from a large dat. Unfortunately, we haven't quite built a user interface for this into our applications. So you can hack around it!
+Dat supports *sparse*, or partial downloads, of datasets.
+This is really useful if you only want a single file from a large dat.
+Unfortunately, we haven't quite built a user interface for this into our applications.
+So you can hack around it!
 
 This will allow you to download a single file from a larger dat, without downloading metadata or any other files.
 
@@ -54,7 +62,8 @@ Serving files over http at http://localhost:8080
 3 connections | Download 0 B/s Upload 0 B/s
 ```
 
-The `--sparse` option tells Dat to only download files you specifically request. See how it works:
+The `--sparse` option tells Dat to only download files you specifically request.
+See how it works:
 
 1. Check out your `./demo` folder, it should be empty.
 2. Open the Dat in your browser.

--- a/docs/usingdat-diy.md
+++ b/docs/usingdat-diy.md
@@ -3,9 +3,11 @@ id: diy-dat
 title: Building with Dat
 ---
 
-In this guide, we will show how to develop applications with the Dat ecosystem. The Dat ecosystem is very modular making it easy to develop custom applications using Dat.
+In this guide, we will show how to develop applications with the Dat ecosystem.
+The Dat ecosystem is very modular making it easy to develop custom applications using Dat.
 
-Dat comes with a built in javascript API we use in Dat Desktop and dat command line. For custom applications, or more control, you can also use the core Dat modules separately.
+Dat comes with a built in javascript API we use in Dat Desktop and dat command line.
+For custom applications, or more control, you can also use the core Dat modules separately.
 
 Use Dat in your JS Application:
 
@@ -16,18 +18,22 @@ This tutorial will cover the second option and get you familiar with the core Da
 
 ### The Dat Core Modules
 
-This tutorial will follow the steps for sharing and downloading files using Dat. In practice, we implement these in [dat-node](https://github.com/datproject/dat-node), a high-level module for using Dat that provides easy access to the core Dat modules.
+This tutorial will follow the steps for sharing and downloading files using Dat.
+In practice, we implement these in [dat-node](https://github.com/datproject/dat-node), a high-level module for using Dat that provides easy access to the core Dat modules.
 
 For any Dat application, there are two essential modules you will start with:
 
 1. [hyperdrive](https://npmjs.org/hyperdrive) for file synchronization and versioning
 2. [hyperdiscovery](https://npmjs.org/hyperdiscovery) helps discover and connect to peers over local networks and the internet
 
-The [Dat CLI](https://npmjs.org/dat) module itself combines these modules and wraps them in a command-line API. We also use the [dat-storage](https://github.com/datproject/dat-storage) module to handle file and key storage. These modules can be swapped out for a similarly compatible module, such as switching storage for [random-access-memory](https://github.com/mafintosh/random-access-memory).
+The [Dat CLI](https://npmjs.org/dat) module itself combines these modules and wraps them in a command-line API.
+We also use the [dat-storage](https://github.com/datproject/dat-storage) module to handle file and key storage.
+These modules can be swapped out for a similarly compatible module, such as switching storage for [random-access-memory](https://github.com/mafintosh/random-access-memory).
 
 ## Getting Started
 
-You will need node and npm installed to build with Dat. [Read more](https://github.com/datproject/dat/blob/master/CONTRIBUTING.md#development-workflow) about our development work flow to learn how we manage our module dependencies during development.
+You will need node and npm installed to build with Dat.
+[Read more](https://github.com/datproject/dat/blob/master/CONTRIBUTING.md#development-workflow) about our development work flow to learn how we manage our module dependencies during development.
 
 ## Download a File
 
@@ -40,7 +46,8 @@ npm install --save hyperdrive random-access-memory hyperdiscovery
 touch index.js
 ```
 
-For this example, we will use random-access-memory for our database (keeping the metadata in memory rather than on the file system). In your `index.js` file, require the main modules and set them up:
+For this example, we will use random-access-memory for our database (keeping the metadata in memory rather than on the file system).
+In your `index.js` file, require the main modules and set them up:
 
 ```js
 var ram = require('random-access-memory')
@@ -56,7 +63,10 @@ archive.ready(function () {
 })
 ```
 
-Notice, the user will input the read key for the second argument. The easiest way to get a file from a hyperdrive archive is to make a read stream. `archive.readFile` accepts the index number of filename for the first argument. To display the file, we can create a file stream and pipe it to `process.stdout`.
+Notice, the user will input the read key for the second argument.
+The easiest way to get a file from a hyperdrive archive is to make a read stream.
+`archive.readFile` accepts the index number of filename for the first argument.
+To display the file, we can create a file stream and pipe it to `process.stdout`.
 
 ```js
 // Make sure your archive has a dat.json file!
@@ -66,7 +76,8 @@ var stream = archive.readFile('dat.json', 'utf-8', function (err, data) {
 })
 ```
 
-Now, you can run the module! To download the `dat.json` file from an archive:
+Now, you can run the module!
+To download the `dat.json` file from an archive:
 
 ```
 node index.js dat://<readKey>
@@ -78,7 +89,8 @@ You should see the `dat.json` file.
 
 With a few more lines of code, the user can enter a file to display from the Dat.
 
-Challenge: create a module that will allow the user to input a Dat read key and a filename: `node bonus.js <dat-readKey> <filename>`. The module will print out that file from the readKey, as we did above:
+Challenge: create a module that will allow the user to input a Dat read key and a filename: `node bonus.js <dat-readKey> <filename>`.
+The module will print out that file from the readKey, as we did above:
 
 ```js
 var stream = archive.readFile(fileName)
@@ -92,13 +104,16 @@ node bonus.js 395e3467bb5b2fa083ee8a4a17a706c5574b740b5e1be6efd65754d4ab7328c2 r
 
 ## Download all files to computer
 
-This module will build on the last module. Instead of displaying a single file, we will download all of the files from a Dat into a local directory.
+This module will build on the last module.
+Instead of displaying a single file, we will download all of the files from a Dat into a local directory.
 
-To download the files to the file system, we are going to use [mirror-folder](https://github.com/mafintosh/mirror-folder). [Read more](/using-fs) about how mirror-folder works with hyperdrive.
+To download the files to the file system, we are going to use [mirror-folder](https://github.com/mafintosh/mirror-folder).
+[Read more](/using-fs) about how mirror-folder works with hyperdrive.
 
 In practice, you should use [dat-storage](https://github.com/datproject/dat-storage) to do this as it'll be more efficient and keep the metadata on disk.
 
-Setup will be the same as before (make sure you install `mirror-folder`). The first part of the module will look the same.
+Setup will be the same as before (make sure you install `mirror-folder`).
+The first part of the module will look the same.
 
 ```js
 var path = require('path')

--- a/docs/usingdat-server.md
+++ b/docs/usingdat-server.md
@@ -3,13 +3,17 @@ id: dat-server
 title: Dats on a Server
 ---
 
-Since Dat is a distributed (peer-to-peer) data sharing tool, a computer must be actively sharing a dat for it to be available. If you're sharing files over Dat, you might want to set up a dedicated server that re-hosts your dat. This means that it'll still be available even after you turn off your personal computer.
+Since Dat is a distributed (peer-to-peer) data sharing tool, a computer must be actively sharing a dat for it to be available.
+If you're sharing files over Dat, you might want to set up a dedicated server that re-hosts your dat.
+This means that it'll still be available even after you turn off your personal computer.
 
-Running Dat on a server can also be used for live backups. As long as you are connected to your server and syncing changes, your server can backup all of your content history - allowing you to view old content later.
+Running Dat on a server can also be used for live backups.
+As long as you are connected to your server and syncing changes, your server can backup all of your content history - allowing you to view old content later.
 
 ## Short instructions
 
-We have built a tool into the Dat CLI called `dat store` which enables you to set up a server to keep your Dats online. The tool also enables you to interact with servers that adhere to the [HTTP Pinning Service API](https://www.datprotocol.com/deps/0003-http-pinning-service-api/).
+We have built a tool into the Dat CLI called `dat store` which enables you to set up a server to keep your Dats online.
+The tool also enables you to interact with servers that adhere to the [HTTP Pinning Service API](https://www.datprotocol.com/deps/0003-http-pinning-service-api/).
 
 ```
 npm install -g dat dat-store
@@ -39,7 +43,8 @@ npm install -g dat dat-store
 
 ### Start A Dat Store
 
-Once the CLI is installed, you can run a Dat Store which will be used for to keep a list of Dats online. By default, it will run on http://localhost:3472
+Once the CLI is installed, you can run a Dat Store which will be used for to keep a list of Dats online.
+By default, it will run on http://localhost:3472
 
 ```
 dat store run-service
@@ -82,7 +87,9 @@ This is handled by the [os-service](https://www.npmjs.com/package/os-service) mo
 dat store install-service
 ```
 
-The service will be called `dat-store` and can be managed by your operating system as you would any other service. To start and stop the service, you'll need to look into the specific commands for your operating system. For example, on Linux with Systemd you can use `sudo systemctl stop dat-store` to stop the service and `sudo systemctl start dat-store` to start it up again.
+The service will be called `dat-store` and can be managed by your operating system as you would any other service.
+To start and stop the service, you'll need to look into the specific commands for your operating system.
+For example, on Linux with Systemd you can use `sudo systemctl stop dat-store` to stop the service and `sudo systemctl start dat-store` to start it up again.
 
 You can uninstall the service when you no longer need it.
 
@@ -132,7 +139,8 @@ dat store add hashbase dat://SOME_KEY_HERE
 
 ### Automatically Track A Folder
 
-The CLI supports a special case for local stores where you can pass it a folder and have it automatically watch for changes and update the Dat in addition to keeping the content online. This can be combined with a remote store to make sure any changes you do to a local folder get synced to the rest of the network and are kept online even if you're offline.
+The CLI supports a special case for local stores where you can pass it a folder and have it automatically watch for changes and update the Dat in addition to keeping the content online.
+This can be combined with a remote store to make sure any changes you do to a local folder get synced to the rest of the network and are kept online even if you're offline.
 
 ```
 # Set up the local store to run as a service

--- a/docs/usingdat-troubleshooting.md
+++ b/docs/usingdat-troubleshooting.md
@@ -3,7 +3,8 @@ id: troubleshooting
 title: Troubleshooting Dat
 ---
 
-We've provided some troubleshooting tips based on issues users have seen. Please [open an issue](https://github.com/datproject/dat/issues/new) or ask us in our [chat room](https://gitter.im/datproject/discussions) if you need help troubleshooting and it is not covered here.
+We've provided some troubleshooting tips based on issues users have seen.
+Please [open an issue](https://github.com/datproject/dat/issues/new) or ask us in our [chat room](https://gitter.im/datproject/discussions) if you need help troubleshooting and it is not covered here.
 
 ### Check Your Version
 
@@ -19,17 +20,23 @@ You should see the Dat semantic version printed, e.g. `13.1.2`.
 
 ## Networking Issues
 
-All Dat transfers happen directly between computers. Dat has various methods for connecting computers but because networking capabilities vary widely we may have issues connecting. Whenever you run a Dat there are several steps to share or download files with peers:
+All Dat transfers happen directly between computers.
+Dat has various methods for connecting computers but because networking capabilities vary widely we may have issues connecting.
+Whenever you run a Dat there are several steps to share or download files with peers:
 
 1. Discovering other sources
 2. Connecting to sources
 3. Sending & Receiving Data
 
-With successful use, Dat will show network counts after connection. If you never see a connection, your network may be restricting discovery or connection. Please try using the dat doctor (see below) between the two computers not connecting. This will help troubleshoot the networks.
+With successful use, Dat will show network counts after connection.
+If you never see a connection, your network may be restricting discovery or connection.
+Please try using the dat doctor (see below) between the two computers not connecting.
+This will help troubleshoot the networks.
 
 ### Dat Doctor
 
-We've included a tool to identify network issues with Dat, the Dat doctor. The Dat doctor will run two tests:
+We've included a tool to identify network issues with Dat, the Dat doctor.
+The Dat doctor will run two tests:
 
 1. Attempt to connect to a public server running Dat.
 2. Attempt a direct connection between two computers. You will need to run the command on both the computers you are trying to share data between.
@@ -51,7 +58,8 @@ Start the doctor by running:
 dat doctor
 ```
 
-For direct connection tests, the doctor will print out a command to run on the other computer, `dat doctor <64-character-string>`. The doctor will run through the key steps in the process of sharing data between computers to help identify the issue.
+For direct connection tests, the doctor will print out a command to run on the other computer, `dat doctor <64-character-string>`.
+The doctor will run through the key steps in the process of sharing data between computers to help identify the issue.
 
 ### Known Networking Issues
 
@@ -59,7 +67,8 @@ For direct connection tests, the doctor will print out a command to run on the o
 
 ## Installation Troubleshooting
 
-To use the Dat command line tool you will need to have [node and npm installed](https://docs.npmjs.com/getting-started/installing-node). Make sure those are installed correctly before installing Dat. Dat only supports Node versions 4 and above.
+To use the Dat command line tool you will need to have [node and npm installed](https://docs.npmjs.com/getting-started/installing-node).
+Make sure those are installed correctly before installing Dat. Dat only supports Node versions 4 and above.
 
 ```
 node -v
@@ -67,7 +76,8 @@ node -v
 
 #### Global Install
 
-The `-g` option installs Dat globally allowing you to run it as a command. Make sure you installed with that option.
+The `-g` option installs Dat globally allowing you to run it as a command.
+Make sure you installed with that option.
 
 * If you receive an `EACCES` error, read [this guide](https://docs.npmjs.com/getting-started/fixing-npm-permissions) on fixing npm permissions.
 * If you receive an `EACCES` error, you may also install dat with sudo: `sudo npm install -g dat`.
@@ -75,7 +85,8 @@ The `-g` option installs Dat globally allowing you to run it as a command. Make 
 
 ## Command Line Debugging
 
-If you are having trouble with a specific command, run with the debug environment variable set to `dat` (and optionally also `dat-node`). This will help us debug any issues:
+If you are having trouble with a specific command, run with the debug environment variable set to `dat` (and optionally also `dat-node`).
+This will help us debug any issues:
 
 ```
 DEBUG=dat,dat-node dat clone dat://<readKey> dir


### PR DESCRIPTION
@RangerMauve @okdistribute let me know if you think this is a good idea! 'No thanks' is totally ok :)

This PR doesn't change any content or formatting of the rendered HTML.

Currently, there's no convention for how the prose of the documentation should be reflected in the text of the markdown. In many places, each paragraph is on a single line, Other places have one sentence per line, and still others put line breaks within sentences.

So, this PR would standardize on one sentence per line.

This makes diffs down the road a lot more readable. If you change wording within a sentence, or change the order of sentences in a paragraph, you end up with a diff that shows what happened.