### PR TITLE
Fix dead www.hypercore-protocol.org link

### DIFF
--- a/docs/learn-more-dat-protocol.md
+++ b/docs/learn-more-dat-protocol.md
@@ -9,6 +9,6 @@ Hypercore Protocol is a protocol for sharing data between computers.
 The *Dat Project* helps shepherd community efforts surrounding the Hyperocre Protocol.
 Find more information about the specifications, Hypercore Protocol working group, and Dat governance:
 
-* [Hypercore Protocol Specifications](https://www.hypercore-protocol.org/)
+* [Hypercore Protocol Specifications](https://hypercore-protocol.org/)
 * [Governance](https://github.com/datproject/governance)
 * [How Dat Works](https://datprotocol.github.io/how-dat-works/) (outdated)


### PR DESCRIPTION
Unfortunately `www.hypercore-protocol.org` does not redirect to `hypercore-protocol.org` (it doesn't resolve at all), see hypercore-protocol/website#2