### PR TITLE
www.hypercore-protocol.org -> hypercore-protocol.org

### DIFF
--- a/docs/learn-more-dat-protocol.md
+++ b/docs/learn-more-dat-protocol.md
@@ -9,6 +9,6 @@ Hypercore Protocol is a protocol for sharing data between computers.
 The *Dat Project* helps shepherd community efforts surrounding the Hypercore Protocol.
 Find more information about the specifications, Hypercore Protocol working group, and Dat governance:
 
-* [Hypercore Protocol Specifications](https://www.hypercore-protocol.org/)
+* [Hypercore Protocol Specifications](https://hypercore-protocol.org/)
 * [Governance](https://github.com/datproject/governance)
 * [How Dat Works](https://datprotocol.github.io/how-dat-works/) (outdated)


### PR DESCRIPTION
www.hypercore-protocol.org does not resolve, but hypercore-protocol.org does 

```
[~]$ nslookup www.hypercore-protocol.org
Server:		192.168.178.1
Address:	192.168.178.1#53

** server can't find www.hypercore-protocol.org: NXDOMAIN

[~]$ nslookup hypercore-protocol.org
Server:		192.168.178.1
Address:	192.168.178.1#53

Non-authoritative answer:
Name:	hypercore-protocol.org
Address: 185.199.111.153
Name:	hypercore-protocol.org
Address: 185.199.108.153
Name:	hypercore-protocol.org
Address: 185.199.110.153
Name:	hypercore-protocol.org
Address: 185.199.109.153
```